### PR TITLE
Add suspend answer; Fix #346

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testCompile 'com.nhaarman:expect.kt:1.0.0'
 
     testCompile  "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testCompile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
+    testCompile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
 
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.0"
 }


### PR DESCRIPTION
This code was inspired by:
- Java wrapper part: https://github.com/square/retrofit/blob/8c93b59dbc57841959f5237cb141ce0b3c18b778/retrofit/src/main/java/retrofit2/HttpServiceMethod.java#L168
- Kotlin wrapper part: https://github.com/square/retrofit/blob/8c93b59dbc57841959f5237cb141ce0b3c18b778/retrofit/src/main/java/retrofit2/KotlinExtensions.kt#L83-L98

I used Java code because kotlin does not allow call suspend functions or lambdas by giving own Continuation. But Kotlin does it under the hood, so Java could do it as well. For example:

```kotlin
fun foo(continuation: Continuation) {
  bar(continuation) //compilation error
}

suspend fun bar() {

}  
```