### PR TITLE
Add infix to stubbing

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/KStubbing.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/KStubbing.kt
@@ -39,7 +39,7 @@ inline fun <T> stubbing(
     KStubbing(mock).stubbing(mock)
 }
 
-inline fun <T : Any> T.stub(stubbing: KStubbing<T>.(T) -> Unit): T {
+inline infix fun <T : Any> T.stub(stubbing: KStubbing<T>.(T) -> Unit): T {
     return apply { KStubbing(this).stubbing(this) }
 }
 


### PR DESCRIPTION
Adding the `infix` to the `stub` function will allow for a more dsl format:

```kotlin
myMock stub {
  on { call() } doReturn someMagicResult
}
```
