### PR TITLE
Return an empty String instead of null when creating a mock

### DIFF
--- a/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/internal/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/com/nhaarman/mockitokotlin2/internal/CreateInstance.kt
@@ -38,6 +38,7 @@ inline fun <reified T : Any> createInstance(): T {
         Long::class -> 0L as T
         Float::class -> 0f as T
         Double::class -> 0.0 as T
+        String::class -> "" as T
         else -> createInstance(T::class)
     }
 }

--- a/tests/src/test/kotlin/test/createinstance/NullCasterTest.kt
+++ b/tests/src/test/kotlin/test/createinstance/NullCasterTest.kt
@@ -11,7 +11,7 @@ class NullCasterTest : TestBase() {
     @Test
     fun createInstance() {
         /* When */
-        val result = createInstance(String::class)
+        val result = createInstance(Any::class)
 
         /* Then */
         expect(result).toBeNull()
@@ -20,12 +20,12 @@ class NullCasterTest : TestBase() {
     @Test
     fun kotlinAcceptsNullValue() {
         /* Given */
-        val s: String = createInstance(String::class)
+        val mockObject: Any = createInstance(Any::class)
 
         /* When */
-        acceptNonNullableString(s)
+        acceptNonNullableObject(mockObject)
     }
 
-    private fun acceptNonNullableString(@Suppress("UNUSED_PARAMETER") s: String) {
+    private fun acceptNonNullableObject(@Suppress("UNUSED_PARAMETER") mockObject: Any) {
     }
 }


### PR DESCRIPTION
See #372 for reference

I believe `String` values in mocks should return `""` by default.

It is a historically 'special' type which has always had some special 'primitive-like' privileges. 
I assume people expect it to return a nice value as well!

Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests?
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
