### PR TITLE
ignore all intelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,20 +5,9 @@ repo
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
-*.iml
 
-.idea/caches/*
-.idea/compiler.xml
-.idea/encodings.xml
-.idea/gradle.xml
-.idea/kotlinc.xml
-.idea/libraries/*
-.idea/misc.xml
-.idea/modules.xml
-.idea/runConfigurations.xml
-.idea/shelf
-.idea/uiDesigner.xml
-.idea/vcs.xml
-.idea/workspace.xml
+# intelliJ
+.idea/
+*.iml
 
 *.orig


### PR DESCRIPTION
Ignore intelliJ files in an easier way.
I stumbled upon this as IntelliJ watned to commit jarRepositories.xml on my machine, this commit ignores this file as well.