### PR TITLE
Automated releases directly to Sonatype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - main
-    tags-ignore:
-      - v* # release tags are automatically generated after a successful CI build, no need to run CI against them
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -39,27 +39,21 @@ For more info and samples, see the [Wiki](https://github.com/mockito/mockito-kot
 
 Mockito-Kotlin is built with Gradle.
 
- - `./gradlew build` builds the project
+ - `./gradlew build` builds and tests the project
  - `./gradlew publishToMavenLocal` installs the maven artifacts in your local repository
- - `./gradlew assemble && ./gradlew test` runs the test suite (See Testing below)
+ - `./gradlew check` runs the test suite (See Testing below)
 
 ### Versioning
 
-Mockito-Kotlin roughly follows SEMVER; version names are parsed from 
-git tags using `git describe`.
+Mockito-Kotlin roughly follows SEMVER
 
 ### Testing
 
 Mockito-Kotlin's test suite is located in a separate `tests` module,
 to allow running the tests using several Kotlin versions whilst still
-keeping the base module at a recent version.  
+keeping the base module at a recent version.
 
-Testing thus must be done in two stages: one to build the base artifact
-to test against, and the actual execution of the tests against the 
-built artifact:
-
- - `./gradlew assemble` builds the base artifact
- - `./gradlew test` runs the tests against the built artifact.
+ - `./gradlew check` runs the checks including tests.
 
 Usually it is enough to test only using the default Kotlin versions; 
 CI will test against multiple versions.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,3 +1,12 @@
 # Releasing
 
-Every change on the main development branch is released to Maven Central.
+1. Every change on the main development branch is released as -SNAPSHOT version
+to Sonatype snapshot repo at https://s01.oss.sonatype.org/content/repositories/snapshots.
+2. In order to release a non-snapshot version to Maven Central push an annotated tag, for example:
+```
+git tag -a -m "Release 3.4.5" 3.4.5
+git push
+```
+3. At the moment, you **may not create releases from GitHub Web UI**.
+Doing so will make the CI build fail because the CI creates the changelog and posts to GitHub releases.
+In the future supporting this would be nice but currently please make releases by pushing from CLI.

--- a/build.gradle
+++ b/build.gradle
@@ -4,15 +4,13 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit-changelog:1.+"
-        classpath "pl.allegro.tech.build:axion-release-plugin:1.12.2-SNAPSHOT"
+        classpath "org.shipkit:shipkit-changelog:1.1.13"
+        classpath "pl.allegro.tech.build:axion-release-plugin:1.13.0"
+        classpath "io.github.gradle-nexus:publish-plugin:1.0.0"
     }
 }
 
-plugins {
-    id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
-}
-
+apply plugin: "io.github.gradle-nexus.publish-plugin"
 apply plugin: "org.shipkit.shipkit-changelog"
 apply plugin: "org.shipkit.shipkit-github-release"
 apply plugin: "pl.allegro.tech.build.axion-release"

--- a/build.gradle
+++ b/build.gradle
@@ -59,3 +59,14 @@ nexusPublishing {
         }
     }
 }
+
+if (version.endsWith("-SNAPSHOT")) {
+    tasks.named("githubRelease") {
+        //snapshot versions do not produce changelog / GitHub releases
+        enabled = false
+    }
+    tasks.named("closeAndReleaseStagingRepository") {
+        //snapshot binaries are available in Sonatype without the need to close the staging repo
+        enabled = false
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "org.shipkit:shipkit-changelog:1.+"
-        classpath "org.shipkit:shipkit-auto-version:1.+"
+        classpath "pl.allegro.tech.build:axion-release-plugin:1.12.2-SNAPSHOT"
     }
 }
 
@@ -13,16 +13,23 @@ plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
 
-apply plugin: "org.shipkit.shipkit-auto-version"
 apply plugin: "org.shipkit.shipkit-changelog"
 apply plugin: "org.shipkit.shipkit-github-release"
+apply plugin: "pl.allegro.tech.build.axion-release"
+
+scmVersion {
+    tag {
+        prefix = ''
+    }
+}
 
 allprojects {
     group = 'org.mockito.kotlin'
+    version = scmVersion.version
 }
 
 tasks.named("generateChangelog") {
-    previousRevision = project.ext.'shipkit-auto-version.previous-tag'
+    previousRevision = scmVersion.previousVersion
     githubToken = System.getenv("GITHUB_TOKEN")
     repository = "mockito/mockito-kotlin"
     releaseTag = project.version

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,8 @@ tasks.named("githubRelease") {
 nexusPublishing {
     repositories {
         if (System.getenv("NEXUS_TOKEN_PWD")) {
-            sonatype { // Publishing to: https://s01.oss.sonatype.org (faster instance)
+            sonatype {
+                // Publishing to: https://s01.oss.sonatype.org (faster instance)
                 nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
                 snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
 

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,3 +1,4 @@
+//Maven publication plugins & configuration
 apply plugin: 'maven-publish'
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,0 @@
-# Version of the produced binaries.
-# The version is inferred by shipkit-auto-version Gradle plugin (https://github.com/shipkit/shipkit-auto-version)
-version=2.2.*
-tagPrefix=


### PR DESCRIPTION
This PR is intended to demonstrate sample usage of new `getPreviousVersion()` API suggested here: https://github.com/allegro/axion-release-plugin/pull/383

Builds are expected to fail ;-) Don't merge it.