### PR TITLE
Add required tags argument to release push command

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ to Sonatype snapshot repo at https://s01.oss.sonatype.org/content/repositories/s
 2. In order to release a non-snapshot version to Maven Central push an annotated tag, for example:
 ```
 git tag -a -m "Release 3.4.5" 3.4.5
-git push
+git push --tags
 ```
 3. At the moment, you **may not create releases from GitHub Web UI**.
 Doing so will make the CI build fail because the CI creates the changelog and posts to GitHub releases.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ to Sonatype snapshot repo at https://s01.oss.sonatype.org/content/repositories/s
 2. In order to release a non-snapshot version to Maven Central push an annotated tag, for example:
 ```
 git tag -a -m "Release 3.4.5" 3.4.5
-git push --tags
+git push origin 3.4.5
 ```
 3. At the moment, you **may not create releases from GitHub Web UI**.
 Doing so will make the CI build fail because the CI creates the changelog and posts to GitHub releases.


### PR DESCRIPTION
Without `--tags`, the push command will state:
```
Everything up-to-date
```

Instead, we have to explicitly list the `--tags` argument to
push tags to the remote.