### PR TITLE
Run release procedure on tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 3.*
   pull_request:
     branches:
       - main
@@ -78,7 +80,7 @@ jobs:
     needs: [build] # build job must pass before we can release
 
     if: github.event_name == 'push'
-        && github.ref == 'refs/heads/main'
+        && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/3.'))
         && github.repository == 'mockito/mockito-kotlin'
         && !contains(toJSON(github.event.commits.*.message), '[skip release]')
 


### PR DESCRIPTION
Running CI actions on tags requires tags to be explicitly listed per the
documentation in
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-branches-and-tags

Also update the logic to make sure we run on tags, not just on the main
branch pushes.
