### PR TITLE
Update link to Sonatype snapshot repo

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 1. Every change on the main development branch is released as -SNAPSHOT version
-to Sonatype snapshot repo at https://s01.oss.sonatype.org/content/repositories/snapshots.
+to Sonatype snapshot repo at https://s01.oss.sonatype.org/content/repositories/snapshots/org/mockito/kotlin/mockito-kotlin.
 2. In order to release a non-snapshot version to Maven Central push an annotated tag, for example:
 ```
 git tag -a -m "Release 3.4.5" 3.4.5


### PR DESCRIPTION
Current link in RELEASING.md doesn't lead directly to 'mockito-kotlin' snapshots repo. This commit fixes the link with valid URL.
