### PR TITLE
Update mockito-core dependency

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
 
-    compile "org.mockito:mockito-core:3.8.0"
+    compile "org.mockito:mockito-core:3.9.0"
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.nhaarman:expect.kt:1.0.0'


### PR DESCRIPTION
`mockito-core:3.8.0` depends on `objenesis:3.1` which causes android instrumentation tests to fail when minSDK < 26 (see: https://github.com/mockito/mockito/issues/2007 for more information.). Updating to `mockito-core:3.9.0` fixes this.

This resolves: https://github.com/mockito/mockito-kotlin/issues/433