### PR TITLE
Enable automated changelog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "org.shipkit:shipkit-changelog:1.1.13"
-        classpath "org.shipkit:shipkit-auto-version:1.1.11"
+        classpath "org.shipkit:shipkit-auto-version:1.1.14"
         classpath "io.github.gradle-nexus:publish-plugin:1.0.0"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,31 +5,22 @@ buildscript {
     }
     dependencies {
         classpath "org.shipkit:shipkit-changelog:1.1.13"
-        classpath "pl.allegro.tech.build:axion-release-plugin:1.13.0"
+        classpath "org.shipkit:shipkit-auto-version:1.1.11"
         classpath "io.github.gradle-nexus:publish-plugin:1.0.0"
     }
 }
 
 apply plugin: "io.github.gradle-nexus.publish-plugin"
+apply plugin: 'org.shipkit.shipkit-auto-version'
 apply plugin: "org.shipkit.shipkit-changelog"
 apply plugin: "org.shipkit.shipkit-github-release"
-apply plugin: "pl.allegro.tech.build.axion-release"
-
-scmVersion {
-    tag {
-        prefix = ''
-    }
-}
 
 allprojects {
     group = 'org.mockito.kotlin'
-    version = scmVersion.version
 }
 
-println "Building version $version"
-
 tasks.named("generateChangelog") {
-    previousRevision = scmVersion.previousVersion
+    previousRevision = project.ext.'shipkit-auto-version.previous-version'
     githubToken = System.getenv("GITHUB_TOKEN")
     repository = "mockito/mockito-kotlin"
     releaseTag = project.version

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,1 @@
+tagPrefix=


### PR DESCRIPTION
Recently **Shipkit Auto Version** plugin got new feature that allows to use version from annotated tag. As the plugin provides information about `previous version` applying it instead of axion plugin will enable automated changelog.  Mockito-Kotlin does not use any prefix for tags so it is required to add `version.properties` file with empty `tagPrefix` property. 
Same plugin replacement has been already done in Mockito project by @mockitoguy.
