### PR TITLE
Remove deprecated verifyZeroInteractions

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
 
-    compile "org.mockito:mockito-core:3.12.4"
+    compile "org.mockito:mockito-core:4.0.0"
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.nhaarman:expect.kt:1.0.0'

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Verification.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Verification.kt
@@ -91,19 +91,6 @@ fun verifyNoInteractions(vararg mocks: Any) {
 }
 
 /**
- * @deprecated
- *
- * Please migrate your code to [verifyNoInteractions].
- */
-@Deprecated(
-      "Use verifyNoInteractions() instead.",
-      ReplaceWith("verifyNoInteractions(vararg mocks: Any)")
-)
-fun verifyZeroInteractions(vararg mocks: Any) {
-    Mockito.verifyZeroInteractions(*mocks)
-}
-
-/**
  * Allows verifying exact number of invocations.
  *
  * Alias for [Mockito.times].

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile files("${rootProject.projectDir}/mockito-kotlin/build/libs/mockito-kotlin-${version}.jar")
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.mockito:mockito-core:2.23.0"
+    compile "org.mockito:mockito-core:4.0.0"
 
     testCompile "junit:junit:4.12"
     testCompile "com.nhaarman:expect.kt:1.0.0"

--- a/tests/src/test/kotlin/test/MockingTest.kt
+++ b/tests/src/test/kotlin/test/MockingTest.kt
@@ -12,6 +12,8 @@ import org.mockito.kotlin.whenever
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.exceptions.verification.WantedButNotInvoked
+import org.mockito.invocation.DescribedInvocation
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.listeners.InvocationListener
 import org.mockito.mock.SerializableMode.BASIC
 import java.io.PrintStream
@@ -182,7 +184,10 @@ class MockingTest : TestBase() {
             fail("Expected an exception")
         } catch (e: WantedButNotInvoked) {
             /* Then */
-            verify(out).println("methods.stringResult();")
+            argumentCaptor<DescribedInvocation>().apply {
+                verify(out).println(capture())
+                expect(lastValue.toString()).toBe("methods.stringResult();")
+            }
         }
     }
 
@@ -314,7 +319,10 @@ class MockingTest : TestBase() {
             fail("Expected an exception")
         } catch (e: WantedButNotInvoked) {
             /* Then */
-            verify(out).println("methods.stringResult();")
+            argumentCaptor<DescribedInvocation>().apply {
+                verify(out).println(capture())
+                expect(lastValue.toString()).toBe("methods.stringResult();")
+            }
         }
     }
 

--- a/tests/src/test/kotlin/test/VerifyTest.kt
+++ b/tests/src/test/kotlin/test/VerifyTest.kt
@@ -4,7 +4,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.junit.Test
-import org.mockito.exceptions.verification.TooLittleActualInvocations
+import org.mockito.exceptions.verification.TooFewActualInvocations
 import org.mockito.exceptions.verification.junit.ArgumentsAreDifferent
 
 class VerifyTest : TestBase() {
@@ -30,7 +30,7 @@ class VerifyTest : TestBase() {
         }
     }
 
-    @Test(expected = TooLittleActualInvocations::class)
+    @Test(expected = TooFewActualInvocations::class)
     fun verifyFailsWithWrongCount() {
         val iface = mock<TestInterface>()
 


### PR DESCRIPTION
Fixes #446.

I just removed the method for now, but if it's preferred to keep it around and call through to `verifyNoMoreInteractions` instead, let me know and I can update the PR.

---

Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests?
   - there were no tests for `verifyZeroInteractions` as far as I can tell
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
