### PR TITLE
Run releases on Mockito-kotlin 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - main
     tags:
       - 3.*
+      - 4.*
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Per https://github.com/mockito/mockito-kotlin/pull/447#issuecomment-940750432 the release on the previously published tag 4.0.0 didn't work, as it wasn't matching our release configuration.