### PR TITLE
Remove jcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small library that provides helper functions to work with [Mockito](https://gi
 
 ## Install
 
-Mockito-Kotlin is available on Maven Central and JCenter.
+Mockito-Kotlin is available on Maven Central.
 For Gradle users, add the following to your `build.gradle`, replacing `x.x.x` with the latest version:
 
 ```groovy

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -7,7 +7,6 @@ buildscript {
 
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -18,7 +17,6 @@ buildscript {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
@@ -28,7 +26,7 @@ dependencies {
     compile "org.mockito:mockito-core:4.0.0"
 
     testCompile 'junit:junit:4.12'
-    testCompile 'com.nhaarman:expect.kt:1.0.0'
+    testCompile 'com.nhaarman:expect.kt:1.0.1'
 
     testCompile  "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile  "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -15,7 +15,6 @@ apply plugin: 'kotlin'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
@@ -25,5 +24,5 @@ dependencies {
     compile "org.mockito:mockito-core:4.0.0"
 
     testCompile "junit:junit:4.12"
-    testCompile "com.nhaarman:expect.kt:1.0.0"
+    testCompile "com.nhaarman:expect.kt:1.0.1"
 }


### PR DESCRIPTION
Removed `JCenter` from `build.gradle` as it is scheduled to be closed in February 2022.
Upgraded to `1.0.1` as `com.nhaarman:expect.kt:1.0.0` can no longer be obtained due to this change.
https://mvnrepository.com/artifact/com.nhaarman/expect.kt

The description of `README` has been fixed at the same time.

## Addition
No changes were made between `com.nhaarman:expect.kt:1.0.0` and `1.0.1` except for the `publish` change.
https://github.com/nhaarman/expect.kt/compare/1.0.0...1.0.1