### PR TITLE
Upgrading Gradle to 6.9.2, Kotlin to 1.4.20, junit to 4.13.2 and mockito to 4.4.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -3,7 +3,7 @@ apply from: '../gradle/publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
 buildscript {
-    ext.kotlin_version = "1.3.50"
+    ext.kotlin_version = "1.4.20"
 
     repositories {
         mavenCentral()

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
 
-    compile "org.mockito:mockito-core:4.0.0"
+    compile "org.mockito:mockito-core:4.5.1"
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.nhaarman:expect.kt:1.0.1'

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     compile "org.mockito:mockito-core:4.5.1"
 
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
     testCompile 'com.nhaarman:expect.kt:1.0.1'
 
     testCompile  "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.3.50'
+    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.4.20'
     println "$project uses Kotlin $kotlin_version"
 
     repositories {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -23,6 +23,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile "org.mockito:mockito-core:4.5.1"
 
-    testCompile "junit:junit:4.12"
+    testCompile 'junit:junit:4.13.2'
     testCompile "com.nhaarman:expect.kt:1.0.1"
 }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     compile files("${rootProject.projectDir}/mockito-kotlin/build/libs/mockito-kotlin-${version}.jar")
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.mockito:mockito-core:4.0.0"
+    compile "org.mockito:mockito-core:4.5.1"
 
     testCompile "junit:junit:4.12"
     testCompile "com.nhaarman:expect.kt:1.0.1"


### PR DESCRIPTION
Upgrading Gradle to 6.9.2, Kotlin to 1.4.20, junit to 4.13.2 and mockito to 4.4.0.