### PR TITLE
Ease verify inOrder for suspending functions

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/KInOrder.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/KInOrder.kt
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.mockito.kotlin
+
+import org.mockito.InOrder
+import org.mockito.verification.VerificationMode
+
+interface KInOrder: InOrder {
+    /**
+     * Verifies certain suspending behavior <b>happened once</b> in order.
+     *
+     * Warning: Only one method call can be verified in the function.
+     * Subsequent method calls are ignored!
+     */
+    fun <T> verifyBlocking(mock: T, f: suspend T.() -> Unit)
+
+    /**
+     * Verifies certain suspending behavior happened at least once / exact number of times / never in order.
+     *
+     * Warning: Only one method call can be verified in the function.
+     * Subsequent method calls are ignored!
+     */
+    fun <T> verifyBlocking(mock: T, mode: VerificationMode, f: suspend T.() -> Unit)
+}

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/internal/KInOrderDecorator.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/internal/KInOrderDecorator.kt
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.mockito.kotlin.internal
+
+import kotlinx.coroutines.runBlocking
+import org.mockito.InOrder
+import org.mockito.kotlin.KInOrder
+import org.mockito.verification.VerificationMode
+
+class KInOrderDecorator(private val inOrder: InOrder) : KInOrder, InOrder by inOrder {
+    override fun <T> verifyBlocking(mock: T, f: suspend T.() -> Unit) {
+        val m = verify(mock)
+        runBlocking { m.f() }
+    }
+
+    override fun <T> verifyBlocking(mock: T, mode: VerificationMode, f: suspend T.() -> Unit) {
+        val m = verify(mock, mode)
+        runBlocking { m.f() }
+    }
+}


### PR DESCRIPTION
Why?
```kotlin
val stub = mock<SomeInterface>()

runBlocking {
  testWith(stub) // testing suspending code
}

stub.inOrder {
  verify().notSuspending()
  // this "worked" before my change, but didn't verify order
  verifyBlocking { suspending() }
  // instead one had to use runBlocking { verify().suspending() }
  // or val v = verify(); runBlocking { v.suspending() }
}
```

Changes:
- Added interface `KInOrder` to allow extending mockito's `InOrder` interface:
  - defined `verifyBlocking` methods with similar definition to those in `Verification`
  - implemented interface with a decorator that takes a mockito `InOrder` and does blocking verification the same way as in `Verification`
- Adjusted return types in `Verification` to provide `KInOrder`:
  - the implementation (`KInOrderDecorator`) is not `internal` so that the `inline fun` declaration continues working
- Added methods to `InOrderOnType` that allow passing a `VerificationMode`.

Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests?
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
