### PR TITLE
Add helper functions for coroutine

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/BDDMockito.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/BDDMockito.kt
@@ -25,8 +25,11 @@
 
 package org.mockito.kotlin
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
 import org.mockito.BDDMockito
 import org.mockito.BDDMockito.BDDMyOngoingStubbing
+import org.mockito.BDDMockito.Then
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.kotlin.internal.SuspendableAnswer
 import org.mockito.stubbing.Answer
@@ -47,10 +50,28 @@ fun <T> given(methodCall: () -> T): BDDMyOngoingStubbing<T> {
 }
 
 /**
+ * Alias for [BDDMockito.given] with a suspending lambda
+ *
+ * Warning: Only last method call can be stubbed in the function.
+ * other method calls are ignored!
+ */
+fun <T> givenBlocking(methodCall: suspend CoroutineScope.() -> T): BDDMockito.BDDMyOngoingStubbing<T> {
+    return runBlocking { BDDMockito.given(methodCall()) }
+}
+
+/**
  * Alias for [BDDMockito.then].
  */
 fun <T> then(mock: T): BDDMockito.Then<T> {
     return BDDMockito.then(mock)
+}
+
+/**
+ * Alias for [Then.should], with suspending lambda.
+ */
+fun <T, R> Then<T>.shouldBlocking(f: suspend T.() -> R): R {
+    val m = should()
+    return runBlocking { m.f() }
 }
 
 /**

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/OngoingStubbing.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/OngoingStubbing.kt
@@ -25,6 +25,8 @@
 
 package org.mockito.kotlin
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.kotlin.internal.SuspendableAnswer
@@ -41,6 +43,16 @@ import kotlin.reflect.KClass
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T> whenever(methodCall: T): OngoingStubbing<T> {
     return Mockito.`when`(methodCall)!!
+}
+
+/**
+ * Enables stubbing suspending methods. Use it when you want the mock to return particular value when particular suspending method is called.
+ *
+ * Warning: Only one method call can be stubbed in the function.
+ * other method calls are ignored!
+ */
+fun <T> wheneverBlocking(methodCall: suspend CoroutineScope.() -> T): OngoingStubbing<T> {
+    return runBlocking { Mockito.`when`(methodCall()) }
 }
 
 /**

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Stubber.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Stubber.kt
@@ -25,6 +25,7 @@
 
 package org.mockito.kotlin
 
+import kotlinx.coroutines.runBlocking
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Stubber
@@ -63,3 +64,14 @@ fun doThrow(vararg toBeThrown: Throwable): Stubber {
 }
 
 fun <T> Stubber.whenever(mock: T) = `when`(mock)
+
+/**
+ * Alias for when with suspending function
+ *
+ * Warning: Only one method call can be stubbed in the function.
+ * Subsequent method calls are ignored!
+ */
+fun <T> Stubber.wheneverBlocking(mock: T, f: suspend T.() -> Unit) {
+    val m = whenever(mock)
+    runBlocking { m.f() }
+}

--- a/mockito-kotlin/src/test/kotlin/org/mockito/kotlin/BDDMockitoKtTest.kt
+++ b/mockito-kotlin/src/test/kotlin/org/mockito/kotlin/BDDMockitoKtTest.kt
@@ -23,7 +23,7 @@ class BDDMockitoKtTest {
     }
 
     @Test
-    fun willSuspendableAnswer_witArgument() = runBlocking {
+    fun willSuspendableAnswer_withArgument() = runBlocking {
         val fixture: SomeInterface = mock()
 
         given(fixture.suspendingWithArg(any())).willSuspendableAnswer {
@@ -32,6 +32,40 @@ class BDDMockitoKtTest {
 
         assertEquals(42, fixture.suspendingWithArg(42))
         then(fixture).should().suspendingWithArg(42)
+        Unit
+    }
+
+    @Test
+    fun willSuspendableAnswer_givenBlocking() {
+        val fixture: SomeInterface = mock()
+
+        givenBlocking { fixture.suspending() }.willSuspendableAnswer {
+            withContext(Dispatchers.Default) { 42 }
+        }
+
+        val result = runBlocking {
+            fixture.suspending()
+        }
+
+        assertEquals(42, result)
+        then(fixture).shouldBlocking { suspending() }
+        Unit
+    }
+
+    @Test
+    fun willSuspendableAnswer_givenBlocking_withArgument() {
+        val fixture: SomeInterface = mock()
+
+        givenBlocking { fixture.suspendingWithArg(any()) }.willSuspendableAnswer {
+            withContext(Dispatchers.Default) { it.getArgument<Int>(0) }
+        }
+
+        val result = runBlocking {
+            fixture.suspendingWithArg(42)
+        }
+
+        assertEquals(42, result)
+        then(fixture).shouldBlocking { suspendingWithArg(42) }
         Unit
     }
 

--- a/mockito-kotlin/src/test/kotlin/test/CoroutinesTest.kt
+++ b/mockito-kotlin/src/test/kotlin/test/CoroutinesTest.kt
@@ -62,6 +62,36 @@ class CoroutinesTest {
     }
 
     @Test
+    fun stubbingSuspending_wheneverBlocking() {
+        /* Given */
+        val m: SomeInterface = mock()
+        wheneverBlocking { m.suspending() }
+            .doReturn(42)
+
+        /* When */
+        val result = runBlocking { m.suspending() }
+
+        /* Then */
+        expect(result).toBe(42)
+    }
+
+    @Test
+    fun stubbingSuspending_doReturn() {
+        /* Given */
+        val m = spy(SomeClass())
+        doReturn(10)
+            .wheneverBlocking(m) {
+                delaying()
+            }
+
+        /* When */
+        val result = runBlocking { m.delaying() }
+
+        /* Then */
+        expect(result).toBe(10)
+    }
+
+    @Test
     fun stubbingNonSuspending() {
         /* Given */
         val m = mock<SomeInterface> {
@@ -394,11 +424,11 @@ interface SomeInterface {
     fun nonsuspending(): Int
 }
 
-class SomeClass {
+open class SomeClass {
 
     suspend fun result(r: Int) = withContext(Dispatchers.Default) { r }
 
-    suspend fun delaying() = withContext(Dispatchers.Default) {
+    open suspend fun delaying() = withContext(Dispatchers.Default) {
         delay(100)
         42
     }


### PR DESCRIPTION
For mocking suspending functions, current mockito-kotlin suggests two ways. 
1. [wrapping test case with runBlocking](https://github.com/mockito/mockito-kotlin/blob/7793ba4898570d41baf4299accf950e517f76db9/mockito-kotlin/src/test/kotlin/test/CoroutinesTest.kt#L167-L176)
2. [using KStubbing.onBlocking function.](https://github.com/mockito/mockito-kotlin/blob/7793ba4898570d41baf4299accf950e517f76db9/mockito-kotlin/src/test/kotlin/test/CoroutinesTest.kt#L25-L27)

For stubbing non-suspending functions, developer can use `Mockito.when` or `Mockito.doReturn` style. If someone uses those style in their tests, whenever developer wants to change non-suspending function to suspending function, developer has to change the style of test code. This burden can be removed if mockito-kotlin supports those style of stubbing for suspending function.

This PR suggests some helper functions for mocking a coroutine function. This allows developer to use `Mockito.when`, `Mockito.doReturn`, BDD style for suspending functions. The syntax is similar to `verifyBlocking` which already exists in mockito-kotlin. 

## Helper functions this PR suggests.

1. wheneverBlocking
```kotlin
// normal function
whenever(m.test())
    .doReturn(42)

// suggestion: for suspending function
wheneverBlocking { m.suspending() }
    .doReturn(42)
```

2. Stubber.wheneverBlocking
```kotlin
// normal function
doReturn(10)
    .whenever(m).test()

// suggestion: for suspending function
doReturn(10)
    .wheneverBlocking(m) {
        delaying()
    }
```

3. givenBlocking & shouldBlocking
```kotlin
// normal function
given(fixture.test()).willAnswer { 42 }

...

then(fixture).should().test()

// suggestion: for suspending function
givenBlocking { fixture.suspending() }.willSuspendableAnswer {
    withContext(Dispatchers.Default) { 42 }
}

...

then(fixture).shouldBlocking { suspending() }
```