### PR TITLE
Exchange explanations between verifyNoInteractions() and verifyNoMoreInteractions()

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Verification.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Verification.kt
@@ -74,7 +74,7 @@ fun <T> verify(mock: T, mode: VerificationMode): T {
 }
 
 /**
- * Checks if any of given mocks has any unverified interaction.
+ * Verifies that no interactions happened on given mocks beyond the previously verified interactions.
  *
  * Alias for [Mockito.verifyNoMoreInteractions].
  */
@@ -83,7 +83,7 @@ fun <T> verifyNoMoreInteractions(vararg mocks: T) {
 }
 
 /**
- * Verifies that no interactions happened on given mocks beyond the previously verified interactions.
+ * Checks if any of given mocks has any unverified interaction.
  *
  * Alias for [Mockito.verifyNoInteractions].
  */


### PR DESCRIPTION
The explanation for `verifyNoInteractions()` and the explanation for `verifyNoMoreInteractions()` seem to be exchanged. This pull request is to undo the exchange.

 - [x] Can you back your code up with tests?
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).