### PR TITLE
Prevent silent mis-stubbing

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/KStubbing.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/KStubbing.kt
@@ -28,6 +28,7 @@ package org.mockito.kotlin
 import org.mockito.kotlin.internal.createInstance
 import kotlinx.coroutines.runBlocking
 import org.mockito.Mockito
+import org.mockito.exceptions.misusing.NotAMockException
 import org.mockito.stubbing.OngoingStubbing
 import kotlin.reflect.KClass
 
@@ -44,6 +45,9 @@ inline fun <T : Any> T.stub(stubbing: KStubbing<T>.(T) -> Unit): T {
 }
 
 class KStubbing<out T : Any>(val mock: T) {
+    init {
+        if(!mockingDetails(mock).isMock) throw NotAMockException("Stubbing target is not a mock!")
+    }
 
     fun <R> on(methodCall: R): OngoingStubbing<R> = Mockito.`when`(methodCall)
 

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/KStubbing.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/KStubbing.kt
@@ -32,7 +32,7 @@ import org.mockito.stubbing.OngoingStubbing
 import kotlin.reflect.KClass
 
 
-inline fun <T> stubbing(
+inline fun <T : Any> stubbing(
     mock: T,
     stubbing: KStubbing<T>.(T) -> Unit
 ) {
@@ -43,7 +43,7 @@ inline fun <T : Any> T.stub(stubbing: KStubbing<T>.(T) -> Unit): T {
     return apply { KStubbing(this).stubbing(this) }
 }
 
-class KStubbing<out T>(val mock: T) {
+class KStubbing<out T : Any>(val mock: T) {
 
     fun <R> on(methodCall: R): OngoingStubbing<R> = Mockito.`when`(methodCall)
 

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Spying.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Spying.kt
@@ -56,7 +56,7 @@ fun <T> spy(value: T): T {
  * Creates a spy of the real object, allowing for immediate stubbing.
  * The spy calls <b>real</b> methods unless they are stubbed.
  */
-inline fun <reified T> spy(value: T, stubbing: KStubbing<T>.(T) -> Unit): T {
+inline fun <reified T : Any> spy(value: T, stubbing: KStubbing<T>.(T) -> Unit): T {
     return spy(value)
         .apply { KStubbing(this).stubbing(this) }!!
 }

--- a/tests/src/test/kotlin/test/OngoingStubbingTest.kt
+++ b/tests/src/test/kotlin/test/OngoingStubbingTest.kt
@@ -242,6 +242,16 @@ class OngoingStubbingTest : TestBase() {
     }
 
     @Test
+    fun stubbingRealObject() {
+        val notAMock = ""
+
+        /* Expect */
+        expectErrorWithMessage("is not a mock!").on {
+            notAMock.stub { }
+        }
+    }
+
+    @Test
     fun stubbingTwiceWithCheckArgumentMatchers_throwsException() {
         /* Expect */
         expectErrorWithMessage("null").on {


### PR DESCRIPTION
Consider the following test:

```kotlin
@Test
fun work_isTheAnswer() {
  whenever(foo.work()) doReturn 42

  assertThat(foo.work()).isEqualTo(42)
}
```

It fails with:

```
1) work_isTheAnswer
value of: work()
expected: 42
but was : 43
	at com.testing.MockTest.work_isTheAnswer
```

### Why?

Because the `foo` object is not a mock but it does _call_ a mock in its implementation. That underlying mock call also returns an `Int`, so Mockito happily stubs that method, instead. Yikes.

We can't solve this in `when`/`whenever` because it is not provided the `Mock` object, just the "result" of the (hopefully) method call to stub. In Kotlin, we can solve this in `KStubbing` as a requirement on its argument. This highlights a pitfall when using `when`/`whenever` that the developer must be certain they are stubbing a `Mock` and not a real implementation. To avoid this pitfall, we should use the `doReturn|Throw` family (see below) or immediately stubbing our mocks:

```kotlin
val foo = mock<Foo> {
  on { work() } doReturn 42
}
```

### How have I not seen this issue before?

Probably because you never put a real implementation into `when`/`whenever` or your method was final, or the underlying method being picked up by Mockito was not returning the same value type. In these cases, Mockito will throw an error. Only in the last case, the error might be confusing:

```
org.mockito.exceptions.misusing.WrongTypeOfReturnValue: 
Integer cannot be returned by work()
work() should return boolean
```

Mockito acknowledges this pitfall in the output of the error as tip 2:

```
2. A spy is stubbed using when(spy.foo()).then() syntax. It is safer to stub spies - 
   - with doReturn|Throw() family of methods. More in javadocs for Mockito.spy() method.
```

### Avoiding this pitfall

Mockito recommends against using `when`/`whenever` and instead to use the `doReturn|Throw` family. This changes the stubbing flow to have the `when`/`whenever` take in the mock so that it can be verified:

```kotlin
doReturn(42).whenever(foo).work()
```

Using our real implementation with this setup yields:

```
org.mockito.exceptions.misusing.NotAMockException: 
Argument passed to when() is not a mock!
Example of correct stubbing:
    doThrow(new RuntimeException()).when(mock).someMethod();
```

We can copy this check in `KStubbing` easily which gives developers the option to consistently construct their mocks:

```kotlin
foo.stub {
  on { work() } doReturn 42
}
```

*After this PR is merged,* the above will throw a similar exception:

```
org.mockito.exceptions.misusing.NotAMockException: Stubbing target is not a mock!
```