### PR TITLE
Fix issue #480 by widening the allowed types for lenient().whenever()

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/LenientStubber.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/LenientStubber.kt
@@ -28,11 +28,11 @@ package org.mockito.kotlin
 import org.mockito.stubbing.LenientStubber
 import org.mockito.stubbing.OngoingStubbing
 
-inline fun <reified T : Any> LenientStubber.whenever(methodCall: T): OngoingStubbing<T> {
+inline fun <reified T> LenientStubber.whenever(methodCall: T): OngoingStubbing<T> {
     return `when`(methodCall)
 }
 
-inline fun <reified T : Any> LenientStubber.whenever(methodCall: () -> T): OngoingStubbing<T> {
+inline fun <reified T> LenientStubber.whenever(methodCall: () -> T): OngoingStubbing<T> {
     return whenever(methodCall())
 }
 

--- a/tests/src/test/kotlin/test/LenientStubberTest.kt
+++ b/tests/src/test/kotlin/test/LenientStubberTest.kt
@@ -34,4 +34,18 @@ open class LenientStubberTest {
 
         Assert.assertEquals("List should contain hello", "hello", mock[1])
     }
+
+    @Test
+    fun unused_and_lenient_stubbings_with_nullable() {
+        val mock = mock<NullableToString>()
+        lenient().whenever(mock.returnsNullableString()).doReturn(null)
+        whenever(mock.returnsNonNullableString()).doReturn("hello")
+
+        Assert.assertEquals("Should return hello", "hello", mock.returnsNonNullableString())
+    }
+
+    private class NullableToString {
+        fun returnsNullableString(): String? = ""
+        fun returnsNonNullableString(): String = ""
+    }
 }


### PR DESCRIPTION
Thank you for submitting a pull request! But first:

 - [ x ] Can you back your code up with tests?
 - [ x ] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).

Issue #480 is caused by constraining the type to `Any`. To fix this, we can update it to have no constraint like the underlying Java code
