### PR TITLE
#488: Change kotlinOptions.jvmTarget to VERSION_1_8

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -50,7 +50,7 @@ dokka {
 
 tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 


### PR DESCRIPTION
This commit addresses issue #488, where Android projects were encountering a build failure with the error message: "Cannot inline bytecode built with JVM target 11." 
The issue was resolved by adjusting the 'jvmTarget' to 'VERSION_1_8,' ensuring compatibility with Android projects. 

 - [X] Can you back your code up with tests?
 * Add mockito-kotlin dependency with testImplementation and androidTestImplementation to an Android project, and mock function works.
 - [X] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).
