### PR TITLE
Bump Nexus publishing plugin to latest stable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath "org.shipkit:shipkit-changelog:1.2.0"
         classpath "org.shipkit:shipkit-auto-version:1.2.2"
-        classpath "io.github.gradle-nexus:publish-plugin:1.0.0"
+        classpath "io.github.gradle-nexus:publish-plugin:1.3.0"
     }
 }
 


### PR DESCRIPTION
Fixes build warning:
```
The org.gradle.util.ConfigureUtil type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.1/userguide/upgrading_version_7
.html#org_gradle_util_reports_deprecations
        at build_b11jx6juucrpzzoteqaolbrqh$_run_closure4.doCall(P:\projects\contrib\github-mockito-kotlin\build.gradle:41)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests?
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).

Manual testing: `gradlew publishToMavenLocal` produced the same artifacts. + Nexus Publish Plugin follows semantic versioning, release notes don't contain any known breaking changes: https://github.com/gradle-nexus/publish-plugin/releases