### PR TITLE
Move tests to included build to separate classpaths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,16 +7,22 @@ buildscript {
         classpath "org.shipkit:shipkit-changelog:1.2.0"
         classpath "org.shipkit:shipkit-auto-version:1.2.2"
         classpath "io.github.gradle-nexus:publish-plugin:1.3.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.9.10"
     }
 }
 
+apply plugin: 'org.gradle.base'
 apply plugin: "io.github.gradle-nexus.publish-plugin"
 apply plugin: 'org.shipkit.shipkit-auto-version'
 apply plugin: "org.shipkit.shipkit-changelog"
 apply plugin: "org.shipkit.shipkit-github-release"
 
-allprojects {
-    group = 'org.mockito.kotlin'
+def test = tasks.register("test") {
+    dependsOn gradle.includedBuild("tests").task(":test")
+}
+tasks.named("check") {
+    dependsOn test
 }
 
 tasks.named("generateChangelog") {

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -5,25 +5,14 @@ apply plugin: 'kotlin'
 apply from: '../gradle/publishing.gradle'
 apply plugin: 'org.jetbrains.dokka'
 
-buildscript {
-    ext.kotlin_version = "1.9.20"
-
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.9.10"
-    }
-}
+group = 'org.mockito.kotlin'
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
 
     api "org.mockito:mockito-core:5.7.0"
@@ -31,8 +20,8 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.nhaarman:expect.kt:1.0.1'
 
-    testImplementation  "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testImplementation  "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation  "org.jetbrains.kotlin:kotlin-stdlib"
+    testImplementation  "org.jetbrains.kotlin:kotlin-test"
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0'
 
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.0"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 include 'mockito-kotlin'
-include 'tests'
+includeBuild 'tests'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -2,13 +2,12 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
-    ext.kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.9.20'
-    println "$project uses Kotlin $kotlin_version"
-
     repositories {
         mavenCentral()
     }
     dependencies {
+        def kotlin_version = System.getenv("KOTLIN_VERSION") ?: '1.9.20'
+        println "$project uses Kotlin $kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -20,15 +19,10 @@ repositories {
     mavenCentral()
 }
 
-tasks.named('compileTestKotlin') {
-    dependsOn ':mockito-kotlin:jar'
-}
-
 dependencies {
-    implementation files("${rootProject.projectDir}/mockito-kotlin/build/libs/mockito-kotlin-${version}.jar")
+    implementation "org.mockito.kotlin:mockito-kotlin"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.mockito:mockito-core:5.7.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "com.nhaarman:expect.kt:1.0.1"

--- a/tests/settings.gradle
+++ b/tests/settings.gradle
@@ -1,0 +1,1 @@
+includeBuild '..'


### PR DESCRIPTION
Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests? existing tests cover it + CI will ensure it's always working
 - [x] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).

Fixes:
```
> Configure project :tests
project ':tests' uses Kotlin 1.9.20

The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build.
This might happen in subprojects that apply the Kotlin plugins with the Gradle 'plugins { ... }' DSL if they specify explicit versions, even if the versions are equal.
Please add the Kotlin plugin to the common parent project or the root project, then remove the versions in the subprojects.
If the parent project does not need the plugin, add 'apply false' to the plugin line.
See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl
The Kotlin plugin was loaded in the following projects: ':mockito-kotlin', ':tests'
```

The solution requires some explanation while refactoring from the old one.
I'll comment on each change to clarify what it does and why it's needed.
This is the Gradle-idiomatic way of sharing code between two "independent" projects.
