### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
 Thank you for submitting a pull request! But first:
 
  - [ ] Can you back your code up with tests?
- - [ ] Keep your commits clean: [squash your commits if necessary](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History).


### PR DESCRIPTION
Is this line still relevant? When this line was added the project was using normal merges for PRs, now that they're being squashed to `main`, is there a reason to keep this line? (I was spending time making the commits really nice because I thought they'll be normal merged.)

---

Also, I recommend changing to this setting (regardless of this PR getting merged or not):
![image](https://github.com/mockito/mockito-kotlin/assets/2906988/68b992e2-3419-4d2d-91ab-d94909169add)
because the others bring in noise to the commits message and the default has inconsistent behavior between 1 commit and many commits. It might be set already.