### PR TITLE
Update gradle-nexus.publish-plugin from 1.3.0 to 2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           java-version: 11
 
       - name: Build and release
-        run: ./gradlew githubRelease publishToSonatype closeAndReleaseStagingRepository releaseSummary
+        run: ./gradlew githubRelease publishToSonatype closeAndReleaseStagingRepositories releaseSummary
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NEXUS_TOKEN_USER: ${{secrets.NEXUS_TOKEN_USER}}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "org.shipkit.shipkit-changelog" version "1.2.0"
     id "org.shipkit.shipkit-github-release" version "1.2.0"
     id "org.shipkit.shipkit-auto-version" version "1.2.2"
-    id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
+    id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
     id "org.jetbrains.kotlin.jvm" version "1.9.20" apply false
     id "org.jetbrains.dokka" version "1.9.10" apply false
 }
@@ -56,7 +56,7 @@ if (isSnapshot) {
         //snapshot versions do not produce changelog / Github releases
         enabled = false
     }
-    tasks.named("closeAndReleaseStagingRepository") {
+    tasks.named("closeAndReleaseStagingRepositories") {
         //snapshot binaries are available in Sonatype without the need to close the staging repo
         enabled = false
     }


### PR DESCRIPTION
> [!WARNING]
> Need help: happy for anyone to take this PR.
> Not sure if this new version is compatible with Shipkit.

Specifically: I can't find the origin of this line in the logs:

```
> Configure project :
Building a -SNAPSHOT version (Github release and Maven Central tasks are skipped)
```

which potentially causes these two tasks to be skipped:
```
> Task :closeSonatypeStagingRepository SKIPPED
> Task :releaseSonatypeStagingRepository SKIPPED
> Task :closeAndReleaseSonatypeStagingRepository UP-TO-DATE
> Task :closeAndReleaseStagingRepository UP-TO-DATE
```

Note that even though we explicitly set `enabled = false`, it's `UP-TO-DATE`, which is confusing.