### PR TITLE
Update mockito to 5.12

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
 
-    api "org.mockito:mockito-core:5.7.0"
+    api "org.mockito:mockito-core:5.12.0"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.nhaarman:expect.kt:1.0.1'


### PR DESCRIPTION
Mockito has had 5 minor version changes since the last time this was updated. It would be nice to bump Mockito core to update the version that users of this library are using for their tests.
