### PR TITLE
Added value class support

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib"
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.9.20"
 
     api "org.mockito:mockito-core:5.7.0"
 

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
@@ -50,9 +50,6 @@ inline fun <reified T : Any> any(): T {
 
 /** Matches anything, including nulls. */
 inline fun <reified T : Any> anyOrNull(): T {
-    if(T::class.isValue)
-        return anyValueClass()
-
     return ArgumentMatchers.any<T>() ?: createInstance()
 }
 

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
@@ -29,7 +29,6 @@ import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers
 import org.mockito.kotlin.internal.createInstance
 import kotlin.reflect.KClass
-import kotlin.reflect.jvm.internal.impl.load.kotlin.JvmType.Object
 
 /** Object argument that is equal to the given value. */
 fun <T> eq(value: T): T {

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
@@ -78,6 +78,7 @@ inline fun <reified T : Any?> anyArray(): Array<T> {
     return ArgumentMatchers.any(Array<T>::class.java) ?: arrayOf()
 }
 
+/** Matches any Kotlin value class with the same boxed type by taking its boxed type. */
 inline fun <reified T > anyValueClass(): T {
     require(T::class.isValue) {
         "${T::class.qualifiedName} is not a value class."

--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -81,7 +81,12 @@ interface Methods {
     fun argAndVararg(s: String, vararg a: String)
 
     fun nonDefaultReturnType(): ExtraInterface
+
+    fun valueClass(v: ValueClass)
 }
+
+@JvmInline
+value class ValueClass(private val content: String)
 
 interface ExtraInterface
 

--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -82,11 +82,15 @@ interface Methods {
 
     fun nonDefaultReturnType(): ExtraInterface
 
-    fun valueClass(v: ValueClass)
+    fun valueClass(v: ValueClass?)
+    fun nestedValueClass(v: NestedValueClass)
 }
 
 @JvmInline
 value class ValueClass(private val content: String)
+
+@JvmInline
+value class NestedValueClass(val value: ValueClass)
 
 interface ExtraInterface
 

--- a/tests/src/test/kotlin/test/MatchersTest.kt
+++ b/tests/src/test/kotlin/test/MatchersTest.kt
@@ -319,6 +319,32 @@ class MatchersTest : TestBase() {
         }
     }
 
+    @Test
+    fun any_forValueClass() {
+        mock<Methods>().apply {
+            valueClass(ValueClass("Content"))
+            verify(this).valueClass(any())
+        }
+    }
+
+    @Test
+    fun anyValueClass_withValueClass() {
+        mock<Methods>().apply {
+            valueClass(ValueClass("Content"))
+            verify(this).valueClass(anyValueClass())
+        }
+    }
+
+    @Test
+    fun anyValueClass_withNonValueClass() {
+        expectErrorWithMessage("kotlin.Float is not a value class.") on {
+            mock<Methods>().apply {
+                float(10f)
+                verify(this).float(anyValueClass())
+            }
+        }
+    }
+
     /**
      * a VarargMatcher implementation for varargs of type [T] that will answer with type [R] if any of the var args
      * matched. Needs to keep state between matching invocations.

--- a/tests/src/test/kotlin/test/MatchersTest.kt
+++ b/tests/src/test/kotlin/test/MatchersTest.kt
@@ -328,6 +328,22 @@ class MatchersTest : TestBase() {
     }
 
     @Test
+    fun anyOrNull_forValueClass() {
+        mock<Methods>().apply {
+            valueClass(ValueClass("Content"))
+            verify(this).valueClass(anyOrNull())
+        }
+    }
+
+    @Test
+    fun anyOrNull_forValueClass_withNull() {
+        mock<Methods>().apply {
+            valueClass(null)
+            verify(this).valueClass(anyOrNull())
+        }
+    }
+
+    @Test
     fun anyValueClass_withValueClass() {
         mock<Methods>().apply {
             valueClass(ValueClass("Content"))
@@ -340,8 +356,17 @@ class MatchersTest : TestBase() {
         expectErrorWithMessage("kotlin.Float is not a value class.") on {
             mock<Methods>().apply {
                 float(10f)
-                verify(this).float(anyValueClass())
+                // Should throw an error because Float is not a value class
+                float(anyValueClass())
             }
+        }
+    }
+
+    @Test
+    fun anyValueClass_withNestedValueClass() {
+        mock<Methods>().apply {
+            nestedValueClass(NestedValueClass(ValueClass("Content")))
+            verify(this).nestedValueClass(anyValueClass())
         }
     }
 


### PR DESCRIPTION
This MR serves to add support for value classes to Mockito Kotlin. Value classes currently break and there is no easy way around them, many users have had issues with this: https://github.com/mockito/mockito-kotlin/issues/445

This MR adds an anyValueClass() and adds it to the any() and anyOrNull() implementation. I expect I may have done a few things non-optimally as I am not too familiar with Mockito's inner workings, but I look forward to feedback from someone who knows more about Mockito argument matchers than me to help me improve this. I do think it is important to get support for value classes.