### PR TITLE
Add stubber (top-level) doSuspendableAnswer()

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Stubber.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Stubber.kt
@@ -28,11 +28,17 @@ package org.mockito.kotlin
 import kotlinx.coroutines.runBlocking
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.kotlin.internal.SuspendableAnswer
+import org.mockito.stubbing.OngoingStubbing
 import org.mockito.stubbing.Stubber
 import kotlin.reflect.KClass
 
 fun <T> doAnswer(answer: (InvocationOnMock) -> T?): Stubber {
     return Mockito.doAnswer { answer(it) }!!
+}
+
+fun <T> doSuspendableAnswer(answer: suspend (KInvocationOnMock) -> T?): Stubber {
+    return Mockito.doAnswer(SuspendableAnswer(answer))
 }
 
 fun doCallRealMethod(): Stubber {


### PR DESCRIPTION
This adds a top-level (stubber) `doSuspendableAnswer`  function, the counterpart of `OngoingStubbing.doSuspendableAnswer`. Rationale: while stubbing a spy I need to check that its caller has put an item into the coroutine context.

I'm not sure about the name "stubber" I used in tests. I can rename them if you come up with a better name.
