### PR TITLE
Update mockito

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.9.20"
 
-    api "org.mockito:mockito-core:5.12.0"
+    api "org.mockito:mockito-core:5.17.0"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.nhaarman:expect.kt:1.0.1'


### PR DESCRIPTION
It's been some time since Mockito has been upgraded, so this upgrades Mockito to the newest version.

Maybe it would also make sense if this is accepted to upgrade Kotlin to some K2 version? Since a relatively large part of the ecosystem has moved to K2 I believe.