### PR TITLE
chore(deps): update mockito-core

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
     implementation "org.jetbrains.kotlin:kotlin-reflect:2.1.20"
 
-    api "org.mockito:mockito-core:5.17.0"
+    api "org.mockito:mockito-core:5.20.0"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.nhaarman:expect.kt:1.0.1'


### PR DESCRIPTION
I had problems using mockito-kotlin with JDK25 and the problem seems to be an old version of byte buddy, which was bumped in newer mockito-core version.

Therefore I suggest to update mockito-core to the newest version :) 