### PR TITLE
#544 Adding value class support to the eq() argument matcher.

### DIFF
--- a/tests/src/test/kotlin/test/EqTest.kt
+++ b/tests/src/test/kotlin/test/EqTest.kt
@@ -94,6 +94,18 @@ class EqTest : TestBase() {
         expect(result).toBeNull()
     }
 
+    @Test
+    fun eqValueClassInstance() {
+        /* Given */
+        val valueClass = ValueClass("Content")
+
+        /* When */
+        val result = eq(valueClass)
+
+        /* Then */
+        expect(result).toBe(valueClass)
+    }
+
     private interface MyInterface
     private open class MyClass : MyInterface
     class ClosedClass

--- a/tests/src/test/kotlin/test/MatchersTest.kt
+++ b/tests/src/test/kotlin/test/MatchersTest.kt
@@ -389,6 +389,41 @@ class MatchersTest : TestBase() {
         }
     }
 
+    @Test
+    fun eq_forValueClass() {
+        val valueClass = ValueClass("Content")
+        mock<Methods>().apply {
+            valueClass(valueClass)
+            verify(this).valueClass(eq(valueClass))
+        }
+    }
+
+    @Test
+    fun eq_withNestedValueClass() {
+        val nestedValueClass = NestedValueClass(ValueClass("Content"))
+        mock<Methods>().apply {
+            nestedValueClass(nestedValueClass)
+            verify(this).nestedValueClass(eq(nestedValueClass))
+        }
+    }
+
+    @Test
+    fun eq_withClosedClass() {
+        val closedClassInstance = Closed()
+        mock<Methods>().apply {
+            closed(closedClassInstance)
+            verify(this).closed(eq(closedClassInstance))
+        }
+    }
+
+    @Test
+    fun eq_withInt() {
+        mock<Methods>().apply {
+            int(3)
+            verify(this).int(eq(3))
+        }
+    }
+
     /**
      * a VarargMatcher implementation for varargs of type [T] that will answer with type [R] if any of the var args
      * matched. Needs to keep state between matching invocations.


### PR DESCRIPTION
This MR fixes #544.

It extends to the value class support that was added to the any() and anyOrNull() implementation by #522.

In this MR value class support is added to eq() in a similar fashion. The addional support is backed with various unit tests.
