### PR TITLE
Fix the output directory for the dokka Javadoc plugin

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 }
 
 dokkaHtml.configure {
-    outputDirectory.set(file("${layout.buildDirectory}/javadoc"))
+    outputDirectory.set(layout.buildDirectory.dir("javadoc"))
 
     dokkaSourceSets {
         named("main") {


### PR DESCRIPTION
Fix the output directory for the dokka Javadoc plugin to the folder "build/javadoc" with the project.

The current output dir would start with a folder named "property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory," within the project folder.

