### PR TITLE
Adding value class support to KArgumentCaptor.

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/internal/CreateInstance.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/internal/CreateInstance.kt
@@ -41,8 +41,15 @@ inline fun <reified T : Any> createInstance(): T {
     }
 }
 
+@Suppress("UNCHECKED_CAST")
 fun <T : Any> createInstance(@Suppress("UNUSED_PARAMETER") kClass: KClass<T>): T {
-    return castNull()
+    return if(kClass.isValue) {
+                val boxImpl =
+                    kClass.java.declaredMethods.single { it.name == "box-impl" && it.parameterCount == 1 }
+                boxImpl.invoke(null, castNull()) as T
+    } else {
+        castNull()
+    }
 }
 
 /**

--- a/tests/src/test/kotlin/test/ArgumentCaptorTest.kt
+++ b/tests/src/test/kotlin/test/ArgumentCaptorTest.kt
@@ -3,9 +3,6 @@ package test
 import com.nhaarman.expect.expect
 import com.nhaarman.expect.expectErrorWithMessage
 import org.junit.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.*
 import java.util.*
 
@@ -341,5 +338,48 @@ class ArgumentCaptorTest : TestBase() {
         val captor = argumentCaptor<Array<String>>()
         verify(m).stringArray(captor.capture())
         expect(captor.firstValue.toList()).toBe(listOf())
+    }
+
+    @Test
+    fun argumentCaptor_value_class() {
+        /* Given */
+        val m: Methods = mock()
+        val valueClass = ValueClass("Content")
+
+        /* When */
+        m.valueClass(valueClass)
+
+        /* Then */
+        val captor = argumentCaptor<ValueClass>()
+        verify(m).valueClass(captor.capture())
+        expect(captor.firstValue).toBe(valueClass)
+    }
+
+    @Test
+    fun argumentCaptor_value_class_withNullValue_usingNonNullable() {
+        /* Given */
+        val m: Methods = mock()
+
+        /* When */
+        m.nullableValueClass(null)
+
+        /* Then */
+        val captor = argumentCaptor<ValueClass>()
+        verify(m).nullableValueClass(captor.capture())
+        expect(captor.firstValue).toBeNull()
+    }
+
+    @Test
+    fun argumentCaptor_value_class_withNullValue_usingNullable() {
+        /* Given */
+        val m: Methods = mock()
+
+        /* When */
+        m.nullableValueClass(null)
+
+        /* Then */
+        val captor = nullableArgumentCaptor<ValueClass>()
+        verify(m).nullableValueClass(captor.capture())
+        expect(captor.firstValue).toBeNull()
     }
 }

--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -86,7 +86,8 @@ interface Methods {
 
     fun nonDefaultReturnType(): ExtraInterface
 
-    fun valueClass(v: ValueClass?)
+    fun valueClass(v: ValueClass)
+    fun nullableValueClass(v: ValueClass?)
     fun nestedValueClass(v: NestedValueClass)
 }
 

--- a/tests/src/test/kotlin/test/MatchersTest.kt
+++ b/tests/src/test/kotlin/test/MatchersTest.kt
@@ -349,16 +349,16 @@ class MatchersTest : TestBase() {
     @Test
     fun anyOrNull_forValueClass() {
         mock<Methods>().apply {
-            valueClass(ValueClass("Content"))
-            verify(this).valueClass(anyOrNull())
+            nullableValueClass(ValueClass("Content"))
+            verify(this).nullableValueClass(anyOrNull())
         }
     }
 
     @Test
     fun anyOrNull_forValueClass_withNull() {
         mock<Methods>().apply {
-            valueClass(null)
-            verify(this).valueClass(anyOrNull())
+            nullableValueClass(null)
+            verify(this).nullableValueClass(anyOrNull())
         }
     }
 


### PR DESCRIPTION
Fixes #530.

This MR will capture the value class arguments by it content/unboxed type in the Java Mockito captor.
In case of value class arguments the captured values are then translated back as boxed value class instances in the methods  `firstValue()`, `secondValue()`, `thirdValue()`, `lastValue()`, `singleValue()` and `allValues()` of the Kotlin captor.

The enhancements are covered with additional unit tests.