### PR TITLE
Add MockedStatic.verify extension fun with lambda last

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/MockedStatic.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/MockedStatic.kt
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.mockito.kotlin
+
+import org.mockito.MockedStatic
+import org.mockito.verification.VerificationMode
+
+/**
+ * Syntax sugar to enable [SAM conversion syntax](https://kotlinlang.org/docs/java-interop.html#sam-conversions)
+ * for [MockedStatic.verify] with a [VerificationMode].
+ *
+ * Example:
+ * ```
+ * fooMockedStatic.verify(times(3)) { Foo.doSomething() }
+ * ```
+ */
+fun <T> MockedStatic<T>.verify(mode: VerificationMode, verification: MockedStatic.Verification) {
+    verify(verification, mode)
+}

--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -129,3 +129,8 @@ interface GenericMethods<T> {
 }
 
 class ThrowableClass(cause: Throwable) : Throwable(cause)
+
+object SomeObject {
+    @JvmStatic
+    fun aStaticMethod() {}
+}

--- a/tests/src/test/kotlin/test/MockedStaticTest.kt
+++ b/tests/src/test/kotlin/test/MockedStaticTest.kt
@@ -1,0 +1,19 @@
+package test
+
+import org.junit.Test
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+
+class MockedStaticTest : TestBase() {
+
+    @Test
+    fun testVerifyExtensionFun() {
+        mockStatic(SomeObject::class.java).use { mocked ->
+            SomeObject.aStaticMethod()
+            SomeObject.aStaticMethod()
+
+            mocked.verify(times(2)) { SomeObject.aStaticMethod() }
+        }
+    }
+}


### PR DESCRIPTION
Thank you for submitting a pull request! But first:

 - [X] Can you back your code up with tests?

See: https://github.com/mockito/mockito/issues/2173

The original method had args `MockedStatic.verify(VerificationMode, Verification)`
but this was changed to `MockedStatic.verify(Verification, VerificationMode)` for consistency with `Mockito.verify(T, VerificationMode)`

From @raphw, the original author:
> No, I don't think I had an intention with the order, possibly to have the lambda last what often works better with languages like Kotlin. But I think consistency is the better goal.

IMO, it's much nicer for Kotlin consumers to keep the `Verification` arg last despite the inconsistency with `Mockito.verify`.

Compare:
```
mocked.verify(
  { SomeObject.aStaticMethod() },
  times(2),
)
```
to:
```
mocked.verify(times(2)) { SomeObject.aStaticMethod() }
```