### PR TITLE
Add wrappers for mockStatic, mockConstruction

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/MockedStatic.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/MockedStatic.kt
@@ -26,7 +26,11 @@
 package org.mockito.kotlin
 
 import org.mockito.MockedStatic
+import org.mockito.stubbing.OngoingStubbing
 import org.mockito.verification.VerificationMode
+
+fun <S, T> MockedStatic<T>.whenever(verification: () -> S): OngoingStubbing<S> =
+    `when` { verification() }
 
 /**
  * Syntax sugar to enable [SAM conversion syntax](https://kotlinlang.org/docs/java-interop.html#sam-conversions)

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
@@ -27,6 +27,8 @@ package org.mockito.kotlin
 
 import org.mockito.Incubating
 import org.mockito.MockSettings
+import org.mockito.MockedConstruction
+import org.mockito.MockedStatic
 import org.mockito.Mockito
 import org.mockito.listeners.InvocationListener
 import org.mockito.mock.SerializableMode
@@ -177,6 +179,34 @@ fun withSettings(
     useConstructor?.let { useConstructor(*it.args) }
     outerInstance?.let { outerInstance(it) }
     if (lenient) strictness(Strictness.LENIENT)
+}
+
+/**
+ * Creates a thread-local mock for static methods on [T].
+ *
+ * @see Mockito.mockStatic
+ */
+inline fun <reified T> mockStatic(): MockedStatic<T> {
+    return Mockito.mockStatic(T::class.java)
+}
+
+/**
+ * Creates a thread-local mock for constructions of [T].
+ *
+ * @see Mockito.mockConstruction
+ */
+inline fun <reified T> mockConstruction(): MockedConstruction<T> {
+    return Mockito.mockConstruction(T::class.java)
+}
+
+/**
+ * Creates a thread-local mock for constructions of [T].
+ *
+ * @param mockInitializer a callback to prepare the methods on a mock after its instantiation
+ * @see Mockito.mockConstruction
+ */
+inline fun <reified T> mockConstruction(mockInitializer: MockedConstruction.MockInitializer<T>): MockedConstruction<T> {
+    return Mockito.mockConstruction(T::class.java, mockInitializer)
 }
 
 class UseConstructor private constructor(val args: Array<Any>) {

--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -133,4 +133,7 @@ class ThrowableClass(cause: Throwable) : Throwable(cause)
 object SomeObject {
     @JvmStatic
     fun aStaticMethod() {}
+
+    @JvmStatic
+    fun aStaticMethodReturningString(): String = "Some Value"
 }

--- a/tests/src/test/kotlin/test/MockingTest.kt
+++ b/tests/src/test/kotlin/test/MockingTest.kt
@@ -16,6 +16,8 @@ import org.mockito.Mockito
 import org.mockito.exceptions.verification.WantedButNotInvoked
 import org.mockito.invocation.DescribedInvocation
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mockConstruction
+import org.mockito.kotlin.mockStatic
 import org.mockito.listeners.InvocationListener
 import org.mockito.mock.SerializableMode.BASIC
 import java.io.PrintStream
@@ -387,6 +389,39 @@ class MockingTest : TestBase() {
             mock<ThrowingConstructor>(useConstructor = parameterless()) {}
         }
     }
+
+    @Test
+    fun mockStatic_stubbing() {
+        mockStatic<SomeObject>().use { mockedStatic ->
+            mockedStatic.whenever { SomeObject.aStaticMethodReturningString() }.thenReturn("Hello")
+
+            expect(SomeObject.aStaticMethodReturningString()).toBe("Hello")
+
+            mockedStatic.verify { SomeObject.aStaticMethodReturningString() }
+        }
+    }
+
+    @Test
+    fun mockConstruction_basic() {
+        mockConstruction<Open>().use { mockedConstruction ->
+            val open = Open()
+
+            expect(mockedConstruction.constructed()).toHaveSize(1)
+            expect(mockedConstruction.constructed().first()).toBeTheSameAs(open)
+        }
+    }
+
+    @Test
+    fun mockConstruction_withInitializer() {
+        mockConstruction<Open> { mock, _ ->
+            whenever(mock.stringResult()).thenReturn("Hello")
+        }.use {
+            val open = Open()
+
+            expect(open.stringResult()).toBe("Hello")
+        }
+    }
+
 
     private interface MyInterface
     private open class MyClass


### PR DESCRIPTION
This adds nice reified functions for `Mockito.mockStatic` and `Mockito.mockConstruction`. This also adds a `whenever` wrapper for `MockedStatic` stubbing.

Before:
```
mockStatic(A::class.java).use { mock ->
  mock.`when`<String> { A.method() }.thenReturn("hi")
}
```

After:
```
mockStatic<A>().use { mock ->
  mock.whenever { A.method() } .thenReturn("hi")
}
```

In the future I'd like to add some documentation with caveats around "static" method stubbing of Kotlin code.

Thank you for submitting a pull request! But first:

 - [X] Can you back your code up with tests?
