### PR TITLE
Make kotlinx-coroutines-core (with runBlocking in it) available as transitive dependency.

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib"
-    compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
     implementation "org.jetbrains.kotlin:kotlin-reflect:2.1.20"
 
     api "org.mockito:mockito-core:5.20.0"


### PR DESCRIPTION
Fixes issue #570 

Due to the code changes runBlocking is needed in every use of Mockito-kotlin, also for projects without coroutines.
That's why Mockito-kotlin should declare 'kotlinx-coroutines-core' as a transitive runtime dependency.

This PR is superseded by PR #575 
