### PR TITLE
Use jvmToolchain API to configure builds

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -43,11 +43,8 @@ dokkaHtml.configure {
     }
 }
 
-tasks.withType(KotlinCompile).configureEach {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
-        targetCompatibility = "11"
-    }
+kotlin {
+    jvmToolchain(11) // This handles Kotlin compilation, Java compilation, and Gradle attributes automatically
 }
 
 javadoc.dependsOn dokkaHtml

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -23,9 +23,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
 }
 
-tasks.withType(KotlinCompile).configureEach {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
-        targetCompatibility = "11"
-    }
+kotlin {
+    jvmToolchain(11) // This handles Kotlin compilation, Java compilation, and Gradle attributes automatically
 }


### PR DESCRIPTION
This fixes a problem where I could not run `./gradlew :tests:test` with Gradle using JDK 17:
```
Could not determine the dependencies of task ':tests:compileJava'.
> Could not resolve all dependencies for configuration ':tests:compileClasspath'.
   > Could not resolve org.mockito.kotlin:mockito-kotlin.
     Required by:
         project :tests
      > Dependency resolution is looking for a library compatible with JVM runtime version 11, but 'project :mockito-kotlin' is only compatible with JVM runtime version 17 or newer.
```

After a bit of research, it seems that Gradle populates the metadata with the mockito-kotlin composite build based on the current JDK, wrongly tagging it as compatible with JVM 17+. It seems like using `jvmToolchain()` API is the recommended solution to this problem: https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support

To test this:
`./gradlew :tests:test` now succeeds

Verify the jvm bytecode level has not changed:
`./gradlew build`
`unzip mockito-kotlin/build/libs/mockito-kotlin-0.0.1-SNAPSHOT.jar -d /tmp/jar`
`javap -v /tmp/jar/org/mockito/kotlin/KStubbing.class`

> major version: 55

Correspondings to Java 11, same as before