### PR TITLE
Add test cases to demo bug with stubbing function returning Result<Boolean>

### DIFF
--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -204,6 +204,8 @@ interface SuspendFunctions {
     suspend fun nullableCharValueClassResult(): CharValueClass?
 
     suspend fun builderMethod(): SuspendFunctions
+
+    suspend fun kotlinResultOfBooleanResult(): Result<Boolean>
 }
 
 @JvmInline value class ValueClass(val content: String)

--- a/tests/src/test/kotlin/test/StubberTest.kt
+++ b/tests/src/test/kotlin/test/StubberTest.kt
@@ -4,11 +4,13 @@ import com.nhaarman.expect.expect
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doCallRealMethod
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
@@ -153,4 +155,30 @@ class StubberTest : TestBase() {
 
             expect(mock.stringResult()).toBe("Test")
         }
+
+    @Test
+    @Ignore("See issue #573")
+    fun `should stub suspendable function call with doSuspendableAnswer returning Result of boolean`() =
+        runTest {
+            val s = mock<SuspendFunctions>()
+            doSuspendableAnswer { Result.success(true) }.whenever(s).kotlinResultOfBooleanResult()
+
+            useResult(s)
+        }
+
+    @Test
+    @Ignore("See issue #573")
+    fun `should stub suspendable function call with doReturn returning Result of boolean`() =
+        runTest {
+            val s = mock<SuspendFunctions>()
+            doReturn(Result.success(123)).whenever(s).kotlinResultOfBooleanResult()
+
+            useResult(s)
+        }
+
+    suspend fun useResult(s: SuspendFunctions): Boolean {
+        // Result<Boolean> is inlined to boolean here
+        val result = s.kotlinResultOfBooleanResult()
+        return result.getOrNull() ?: false
+    }
 }


### PR DESCRIPTION
Failing test cases to demonstrate #573 issue

Running the test cases results in:
```
java.lang.ClassCastException: class kotlin.Result cannot be cast to class java.lang.Boolean (kotlin.Result is in unnamed module of loader 'app'; java.lang.Boolean is in module java.base of loader 'bootstrap')
	at test.StubberTest.useResult(StubberTest.kt:180)
	at test.StubberTest$should stub suspendable function call with doSuspendableAnswer returning Result of boolean$1.invokeSuspend(StubberTest.kt:165)
	at test.StubberTest$should stub suspendable function call with doSuspendableAnswer returning Result of boolean$1.invoke(StubberTest.kt)
	at test.StubberTest$should stub suspendable function call with doSuspendableAnswer returning Result of boolean$1.invoke(StubberTest.kt)
	at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt$runTest$2$1$1.invokeSuspend(TestBuilders.kt:317)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.test.TestDispatcher.processEvent$kotlinx_coroutines_test(TestDispatcher.kt:24)
...
```