### PR TITLE
Fix eq() matcher NPE with nullable value class and null value

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
@@ -88,9 +88,14 @@ inline fun <reified T> anyValueClass(): T {
 
 /** Matches an argument that is equal to the given Kotlin value class value. */
 inline fun <reified T> eqValueClass(value: T): T {
+    if (value == null) {
+        @Suppress("UNCHECKED_CAST")
+        return ArgumentMatchers.eq<T>(null) as T
+    }
+
     require(value::class.isValue) { "${value::class.qualifiedName} is not a value class." }
 
-    val unboxed = value?.unboxValueClass()
+    val unboxed = value.unboxValueClass()
     val matcher = AdditionalMatchers.or(ArgumentMatchers.eq(value), ArgumentMatchers.eq(unboxed))
 
     return (matcher ?: unboxed).toKotlinType(T::class)

--- a/tests/src/test/kotlin/test/MatchersTest.kt
+++ b/tests/src/test/kotlin/test/MatchersTest.kt
@@ -672,6 +672,22 @@ class MatchersTest : TestBase() {
                 verify(this).nestedValueClass(eq(nestedValueClass))
             }
         }
+
+        @Test
+        fun eqNullableValueClass_nullValue() {
+            mock<SynchronousFunctions>().apply {
+                nullableValueClass(null)
+                verify(this).nullableValueClass(eq(null))
+            }
+        }
+
+        @Test
+        fun eqNullableLongValueClass_nullValue() {
+            mock<SynchronousFunctions>().apply {
+                nullableLongValueClass(null)
+                verify(this).nullableLongValueClass(eq(null))
+            }
+        }
     }
 
     class OtherMatchersTest {


### PR DESCRIPTION
Thank you for submitting a pull request! But first:

 - [x] Can you back your code up with tests?
 - [x] Please run `./gradlew spotlessApply :tests:spotlessApply` for auto-formatting.

---

## Summary

This PR fixes the NPE issue in `eq()` matcher when used with nullable value class and null value.

Fixes #577

## Problem

After #545 added value class support to `eq()`, using `eq(null)` with a nullable value class type throws `NullPointerException`:

```kotlin
@JvmInline
value class MyValueClass(val value: Long)

interface Foo {
    fun bar(x: MyValueClass?)
}

// This throws NPE in 6.2.0+
verify(foo).bar(eq(null))
```

## Root Cause

In `eqValueClass()`, the code accesses `value::class` before checking if `value` is null:

```kotlin
inline fun <reified T> eqValueClass(value: T): T {
    require(value::class.isValue) { ... }  // NPE when value is null
    ...
}
```

## Solution

Add a null check at the beginning of `eqValueClass()`:

```kotlin
if (value == null) {
    @Suppress("UNCHECKED_CAST")
    return ArgumentMatchers.eq<T>(null) as T
}
```

This follows the existing pattern used in `toKotlinType()` in `ValueClassSupport.kt`.

## Changes

- `Matchers.kt`: Add null check in `eqValueClass()`
- `MatchersTest.kt`: Add test cases for nullable value class with null value
