### PR TITLE
Fix eq() matcher NPE with nullable value class and null value

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Matchers.kt
@@ -37,7 +37,7 @@ import org.mockito.kotlin.internal.valueClassInnerClass
 
 /** Matches an argument that is equal to the given value. */
 inline fun <reified T : Any?> eq(value: T): T {
-    if (T::class.isValue) return eqValueClass(value)
+    if (value != null && T::class.isValue) return eqValueClass(value)
 
     return ArgumentMatchers.eq(value) ?: value
 }
@@ -87,10 +87,10 @@ inline fun <reified T> anyValueClass(): T {
 }
 
 /** Matches an argument that is equal to the given Kotlin value class value. */
-inline fun <reified T> eqValueClass(value: T): T {
+inline fun <reified T : Any> eqValueClass(value: T): T {
     require(value::class.isValue) { "${value::class.qualifiedName} is not a value class." }
 
-    val unboxed = value?.unboxValueClass()
+    val unboxed = value.unboxValueClass()
     val matcher = AdditionalMatchers.or(ArgumentMatchers.eq(value), ArgumentMatchers.eq(unboxed))
 
     return (matcher ?: unboxed).toKotlinType(T::class)

--- a/tests/src/test/kotlin/test/MatchersTest.kt
+++ b/tests/src/test/kotlin/test/MatchersTest.kt
@@ -672,6 +672,24 @@ class MatchersTest : TestBase() {
                 verify(this).nestedValueClass(eq(nestedValueClass))
             }
         }
+
+        @Test
+        fun eqNullableValueClass_nullValue() {
+            val valueClass = null as ValueClass?
+            mock<SynchronousFunctions>().apply {
+                nullableValueClass(valueClass)
+                verify(this).nullableValueClass(eq(valueClass))
+            }
+        }
+
+        @Test
+        fun eqNullableLongValueClass_nullValue() {
+            val longValueClass = null as LongValueClass?
+            mock<SynchronousFunctions>().apply {
+                nullableLongValueClass(longValueClass)
+                verify(this).nullableLongValueClass(eq(longValueClass))
+            }
+        }
     }
 
     class OtherMatchersTest {


### PR DESCRIPTION
Fixes #577

I took #578 as starting point, but it turned out that the provided tests did not actually fail when `eq()` is called with an inline value null. In that case the `T::class` in eq() is then equal to `KClass<Void>`.
After casting the null value in the tests explicity to `ValueClass?`/`LongValueClass?`, the tests started to exhibit the NPE.

I decided to take a slightly different turn in the actual main line fix: I've added the null check to `eq()`. 
The `eqValueClass()` function has only be introduced with release 6.2.0, so I felt it appropriate to reduce the typeParameter of the function to `T: Any`, so it only accepts non-null values onwards.

