### PR TITLE
Add helper to mock module-level extension functions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 Thank you for submitting a pull request! But first:
 
  - [ ] Can you back your code up with tests?
- - [ ] Please run `./gradlew spotlessApply :tests:spotlessApply` for auto-formatting.
+ - [ ] Please run `./gradlew spotlessApply` for auto-formatting.

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ tasks.named("check") {
     dependsOn test
 }
 
+tasks.register("spotlessApply") {
+    dependsOn gradle.includedBuild("tests").task(":spotlessApply")
+}
+
 def isSnapshot = version.endsWith("-SNAPSHOT")
 def githubTokenProvider = providers.environmentVariable("GITHUB_TOKEN").orElse("")
 def githubShaProvider = providers.environmentVariable("GITHUB_SHA").orElse("")

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
@@ -28,6 +28,9 @@ package org.mockito.kotlin
 import java.lang.reflect.Modifier
 import kotlin.DeprecationLevel.ERROR
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.extensionReceiverParameter
+import kotlin.reflect.jvm.javaMethod
 import org.mockito.MockSettings
 import org.mockito.MockedConstruction
 import org.mockito.MockedStatic
@@ -305,6 +308,51 @@ inline fun <reified T> mockConstruction(
     mockInitializer: MockedConstruction.MockInitializer<T>
 ): MockedConstruction<T> {
     return Mockito.mockConstruction(T::class.java, mockInitializer)
+}
+
+/**
+ * Creates a thread-local mock for the static methods of the class that contains this top-level
+ * extension function.
+ *
+ * Top-level Kotlin extension functions compile to static methods in a `*Kt` class. This helper
+ * simplifies creating a [MockedStatic] for them.
+ *
+ * Usage:
+ * ```
+ * fun String.isHello(): Boolean = this == "Hello"
+ *
+ * mockExtensionFun(String::isHello).use {
+ *     whenever("test".isHello()).thenReturn(true)
+ * }
+ * ```
+ *
+ * For overloaded extension functions, specify the type to disambiguate:
+ * ```
+ * fun String.isHello(): Boolean = this == "Hello"
+ * fun String.isHello(mood: String): Boolean = this == "Hello" && mood == "happy"
+ *
+ * val ref: KFunction2<String, String, Boolean> = String::isHello
+ * mockExtensionFun(ref).use {
+ *     whenever("test".isHello("sad")).thenReturn(true)
+ * }
+ * ```
+ *
+ * Note: member extension functions (extension functions declared inside a class) do not need this
+ * helper. They can be mocked by creating a regular [mock] of the containing class.
+ *
+ * @param function a reference to the top-level extension function to mock.
+ * @see Mockito.mockStatic
+ */
+fun mockExtensionFun(function: KFunction<*>): MockedStatic<*> {
+    requireNotNull(function.extensionReceiverParameter) {
+        "Expected an extension function reference, but $function has no extension receiver."
+    }
+    val declaringClass =
+        requireNotNull(function.javaMethod?.declaringClass) {
+            "Could not determine declaring class for function $function. " +
+                "Ensure this is a top-level extension function reference."
+        }
+    return Mockito.mockStatic(declaringClass)
 }
 
 class UseConstructor private constructor(val args: Array<Any>) {

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
@@ -323,17 +323,17 @@ inline fun <reified T> mockConstruction(
  *
  * mockExtensionFun(String::isHello).use {
  *     whenever("test".isHello()).thenReturn(true)
+ *     println("test".isHello()) // "true"
  * }
  * ```
  *
- * For overloaded extension functions, specify the type to disambiguate:
+ * When using matchers, all arguments including the receiver must use matchers:
  * ```
- * fun String.isHello(): Boolean = this == "Hello"
- * fun String.isHello(mood: String): Boolean = this == "Hello" && mood == "happy"
+ * fun String.hasPrefix(prefix: String): Boolean = this.startsWith(prefix)
  *
- * val ref: KFunction2<String, String, Boolean> = String::isHello
- * mockExtensionFun(ref).use {
- *     whenever("test".isHello("sad")).thenReturn(true)
+ * mockExtensionFun(String::hasPrefix).use {
+ *     whenever(any<String>().hasPrefix(eq("foo"))).thenReturn(true)
+ *     println("bar".hasPrefix("foo")) // "true"
  * }
  * ```
  *

--- a/tests/src/test/kotlin/test/Classes.kt
+++ b/tests/src/test/kotlin/test/Classes.kt
@@ -262,3 +262,18 @@ object SomeObject {
 
     @JvmStatic fun aStaticMethodReturningString(): String = "Some Value"
 }
+
+// Top-level extension functions for testing mockExtensionFun
+
+fun String.isEqualTo(compare: String): Boolean = this == compare
+
+fun String.isHello(): Boolean = this == "Hello"
+
+fun String.isHello(mood: String): Boolean = this == "Hello" && mood == "happy"
+
+// Classes for member extension function test
+class Foo {
+    fun Bar.foobar(): String = this@Foo.toString() + this.toString()
+}
+
+class Bar

--- a/tests/src/test/kotlin/test/MockingTest.kt
+++ b/tests/src/test/kotlin/test/MockingTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.UseConstructor.Companion.withArguments
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.mockConstruction
 import org.mockito.kotlin.mockExtensionFun
@@ -558,6 +559,16 @@ class MockingTest : TestBase() {
             whenever("a".isEqualTo("b")).thenReturn(true)
 
             expect("a".isEqualTo("b")).toBe(true)
+        }
+    }
+
+    @Test
+    fun mockExtensionFun_withMatchers_returnsMockedValue() {
+        mockExtensionFun(String::isEqualTo).use {
+            whenever(any<String>().isEqualTo(eq("b"))).thenReturn(true)
+
+            expect("a".isEqualTo("b")).toBe(true)
+            expect("a".isEqualTo("c")).toBe(false)
         }
     }
 

--- a/tests/src/test/kotlin/test/MockingTest.kt
+++ b/tests/src/test/kotlin/test/MockingTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.expect.fail
 import java.io.PrintStream
 import java.io.Serializable
 import java.util.*
+import kotlin.reflect.KFunction2
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.Mockito
@@ -18,6 +19,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.mockConstruction
+import org.mockito.kotlin.mockExtensionFun
 import org.mockito.kotlin.mockObject
 import org.mockito.kotlin.mockStatic
 import org.mockito.kotlin.verify
@@ -548,6 +550,42 @@ class MockingTest : TestBase() {
                 val m = MyClass()
                 mockObject(m)
             }
+    }
+
+    @Test
+    fun mockExtensionFun_returnsMockedValue() {
+        mockExtensionFun(String::isEqualTo).use {
+            whenever("a".isEqualTo("b")).thenReturn(true)
+
+            expect("a".isEqualTo("b")).toBe(true)
+        }
+    }
+
+    @Test
+    fun mockExtensionFun_overloaded_returnsMockedValue() {
+        val ref: KFunction2<String, String, Boolean> = String::isHello
+        mockExtensionFun(ref).use {
+            whenever("test".isHello("sad")).thenReturn(true)
+
+            expect("test".isHello("sad")).toBe(true)
+        }
+    }
+
+    @Test
+    fun mockExtensionFun_nonExtensionFunction_throwsIllegalArgument() {
+        expectErrorWithMessage("has no extension receiver") on
+            {
+                mockExtensionFun(Open::stringResult)
+            }
+    }
+
+    @Test
+    fun memberExtensionFunction_mockedByCreatingMockHost() {
+        val foo = mock<Foo>()
+        val bar = Bar()
+        whenever(with(foo) { bar.foobar() }).thenReturn("mocked")
+
+        expect(with(foo) { bar.foobar() }).toBe("mocked")
     }
 
     object MyObjectNoStatic {


### PR DESCRIPTION
Kotlin lang ref: https://kotlinlang.org/docs/extensions.html

New syntax sugar feature: a helper to mock non-member extension functions.
Note the implementation is just `mockStatic` on the declaring `FooKt` class, so all declared extension functions would be mocked at the same time. There's no way to mock only one of the extension funs.

Also update the spotless task so you don't need to include `:tests:spotlessApply`