### PR TITLE
Add first-class support for mocking object singletons

### DIFF
--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
     implementation "org.jetbrains.kotlin:kotlin-reflect:2.1.20"
 
-    api "org.mockito:mockito-core:5.20.0"
+    api "org.mockito:mockito-core:5.23.0"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.nhaarman:expect.kt:1.0.1'

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/MockedObject.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/MockedObject.kt
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Niek Haarman
+ * Copyright (c) 2007 Mockito contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.mockito.kotlin
+
+import org.mockito.MockedSingleton
+import org.mockito.MockedStatic
+import org.mockito.ScopedMock
+
+/**
+ * Wraps a [MockedSingleton] and an optional [MockedStatic] to provide combined mocking of both
+ * instance and static methods on Kotlin `object` declarations.
+ *
+ * When a Kotlin `object` has `@JvmStatic` methods, Kotlin compiles them as real JVM static methods.
+ * Calls from Kotlin bytecode use `invokestatic`, bypassing the singleton instance mock. This class
+ * transparently combines both mocking mechanisms so that `@JvmStatic` methods are also intercepted.
+ */
+class MockedObject<T>(
+    private val singleton: MockedSingleton<T>,
+    private val static: MockedStatic<T>?,
+) : ScopedMock {
+
+    /** Returns `true` if static method mocking is active for this object. */
+    val isMockingStatic: Boolean
+        get() = static != null
+
+    override fun isClosed(): Boolean = singleton.isClosed
+
+    override fun close() {
+        static?.close()
+        singleton.close()
+    }
+
+    override fun closeOnDemand() {
+        static?.closeOnDemand()
+        singleton.closeOnDemand()
+    }
+}

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
@@ -29,6 +29,7 @@ import kotlin.DeprecationLevel.ERROR
 import kotlin.reflect.KClass
 import org.mockito.MockSettings
 import org.mockito.MockedConstruction
+import org.mockito.MockedSingleton
 import org.mockito.MockedStatic
 import org.mockito.Mockito
 import org.mockito.listeners.InvocationListener
@@ -216,6 +217,64 @@ inline fun <reified T> mockStatic(defaultAnswer: Answer<Any>? = null): MockedSta
  */
 inline fun <reified T> mockConstruction(): MockedConstruction<T> {
     return Mockito.mockConstruction(T::class.java)
+}
+
+/**
+ * Creates a thread-local mock for an `object` or `companion object` singleton.
+ *
+ * NOTE: This returns a [MockedSingleton] which must be closed after test execution to prevent
+ * mocking state from leaking to other test cases. You can do this with a `.use {}` block or by
+ * calling [MockedSingleton.close] manually.
+ *
+ * Example usage:
+ * ```
+ * mockObject(MyObject).use {
+ *     whenever(MyObject.foo()).thenReturn("hello")
+ * }
+ * ```
+ *
+ * or with a `companion object` with method `bar()`:
+ * ```
+ * mockObject(MyClass.Companion).use {
+ *     whenever(MyClass.bar()).thenReturn("hello")
+ * }
+ * ```
+ *
+ * @see Mockito.mockSingleton
+ */
+fun <T : Any> mockObject(instance: T): MockedSingleton<T> {
+    if (instance::class.objectInstance == null && !instance::class.isCompanion) {
+        throw MockitoKotlinException("$instance is not an object or companion object")
+    }
+    return Mockito.mockSingleton(instance)
+}
+
+/**
+ * Creates a thread-local mock for an `object` or `companion object` singleton, allowing for
+ * immediate stubbing.
+ *
+ * NOTE: This returns a [MockedSingleton] which must be closed after test execution to prevent
+ * mocking state from leaking to other test cases. You can do this with a `.use {}` block or by
+ * calling [MockedSingleton.close] manually.
+ *
+ * Example usage:
+ * ```
+ * mockObject(MyObject) {
+ *     on { foo() } doReturn "hello"
+ * }.use { ... }
+ * ```
+ *
+ * or with a `companion object` with method `bar()`:
+ * ```
+ * mockObject(MyClass.Companion) {
+ *     on { bar() } doReturn "hello"
+ * }.use { ... }
+ * ```
+ *
+ * @see Mockito.mockSingleton
+ */
+fun <T : Any> mockObject(instance: T, stubbing: KStubbing<T>.(T) -> Unit): MockedSingleton<T> {
+    return mockObject(instance).apply { KStubbing(instance).stubbing(instance) }
 }
 
 /**

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
@@ -25,11 +25,11 @@
 
 package org.mockito.kotlin
 
+import java.lang.reflect.Modifier
 import kotlin.DeprecationLevel.ERROR
 import kotlin.reflect.KClass
 import org.mockito.MockSettings
 import org.mockito.MockedConstruction
-import org.mockito.MockedSingleton
 import org.mockito.MockedStatic
 import org.mockito.Mockito
 import org.mockito.listeners.InvocationListener
@@ -222,9 +222,9 @@ inline fun <reified T> mockConstruction(): MockedConstruction<T> {
 /**
  * Creates a thread-local mock for an `object` or `companion object` singleton.
  *
- * NOTE: This returns a [MockedSingleton] which must be closed after test execution to prevent
- * mocking state from leaking to other test cases. You can do this with a `.use {}` block or by
- * calling [MockedSingleton.close] manually.
+ * NOTE: This returns a [MockedObject] which must be closed after test execution to prevent mocking
+ * state from leaking to other test cases. You can do this with a `.use {}` block or by calling
+ * [MockedObject.close] manually.
  *
  * Example usage:
  * ```
@@ -239,23 +239,23 @@ inline fun <reified T> mockConstruction(): MockedConstruction<T> {
  *     whenever(MyClass.bar()).thenReturn("hello")
  * }
  * ```
- *
- * @see Mockito.mockSingleton
  */
-fun <T : Any> mockObject(instance: T): MockedSingleton<T> {
+fun <T : Any> mockObject(instance: T): MockedObject<T> {
     if (instance::class.objectInstance == null && !instance::class.isCompanion) {
         throw MockitoKotlinException("$instance is not an object or companion object")
     }
-    return Mockito.mockSingleton(instance)
+    val singleton = Mockito.mockSingleton(instance)
+    val static = createMockedStaticIfNeeded(instance)
+    return MockedObject(singleton, static)
 }
 
 /**
  * Creates a thread-local mock for an `object` or `companion object` singleton, allowing for
  * immediate stubbing.
  *
- * NOTE: This returns a [MockedSingleton] which must be closed after test execution to prevent
- * mocking state from leaking to other test cases. You can do this with a `.use {}` block or by
- * calling [MockedSingleton.close] manually.
+ * NOTE: This returns a [MockedObject] which must be closed after test execution to prevent mocking
+ * state from leaking to other test cases. You can do this with a `.use {}` block or by calling
+ * [MockedObject.close] manually.
  *
  * Example usage:
  * ```
@@ -270,11 +270,29 @@ fun <T : Any> mockObject(instance: T): MockedSingleton<T> {
  *     on { bar() } doReturn "hello"
  * }.use { ... }
  * ```
- *
- * @see Mockito.mockSingleton
  */
-fun <T : Any> mockObject(instance: T, stubbing: KStubbing<T>.(T) -> Unit): MockedSingleton<T> {
+fun <T : Any> mockObject(instance: T, stubbing: KStubbing<T>.(T) -> Unit): MockedObject<T> {
     return mockObject(instance).apply { KStubbing(instance).stubbing(instance) }
+}
+
+/**
+ * If [instance] is a top-level `object` (not a companion) with `@JvmStatic` methods, creates a
+ * [MockedStatic] for its class. Returns `null` otherwise.
+ */
+private fun <T : Any> createMockedStaticIfNeeded(instance: T): MockedStatic<T>? {
+    // Companion objects don't need mockStatic — calling Kotlin code always invokes the underlying
+    // instance method even for @JvmStatic methods so mockSingleton is sufficient.
+    if (instance::class.isCompanion) return null
+
+    val javaClass = instance::class.java
+    val hasStaticMethods =
+        javaClass.declaredMethods.any { method ->
+            Modifier.isStatic(method.modifiers) && !method.isSynthetic
+        }
+
+    if (!hasStaticMethods) return null
+
+    return Mockito.mockStatic(javaClass) as MockedStatic<T>
 }
 
 /**

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/MockitoKotlinException.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/MockitoKotlinException.kt
@@ -25,4 +25,5 @@
 
 package org.mockito.kotlin
 
-class MockitoKotlinException(message: String?, cause: Throwable?) : RuntimeException(message, cause)
+class MockitoKotlinException(message: String?, cause: Throwable? = null) :
+    RuntimeException(message, cause)

--- a/tests/src/test/kotlin/test/MockingTest.kt
+++ b/tests/src/test/kotlin/test/MockingTest.kt
@@ -487,12 +487,29 @@ class MockingTest : TestBase() {
     }
 
     @Test
-    fun mockStatic_Object_With_JvmStatic_method() {
-        mockStatic<MyObject>().use { mock ->
-            mock.whenever { MyObject.helloStatic() }.thenReturn("stubbed")
+    fun mockObject_JvmStatic_method() {
+        mockObject(MyObject).use {
+            whenever(MyObject.helloStatic()).thenReturn("stubbed_via_mockObject")
 
-            expect(MyObject.helloStatic()).toBe("stubbed")
+            expect(MyObject.helloStatic()).toBe("stubbed_via_mockObject")
         }
+    }
+
+    @Test
+    fun mockObject_mixed_regular_and_JvmStatic_methods() {
+        mockObject(MyObject).use {
+            whenever(MyObject.hello()).thenReturn("regular_stubbed")
+            whenever(MyObject.helloStatic()).thenReturn("static_stubbed")
+
+            expect(MyObject.hello()).toBe("regular_stubbed")
+            expect(MyObject.helloStatic()).toBe("static_stubbed")
+            expect(it.isMockingStatic).toBe(true)
+        }
+    }
+
+    @Test
+    fun mockObject_without_JvmStatic_does_not_use_mockStatic() {
+        mockObject(MyObjectNoStatic).use { expect(it.isMockingStatic).toBe(false) }
     }
 
     @Test
@@ -533,11 +550,13 @@ class MockingTest : TestBase() {
             }
     }
 
+    object MyObjectNoStatic {
+        fun hello(): String = "no_static"
+    }
+
     object MyObject {
         fun hello(): String = "unstubbed"
 
-        // This will compile to a static method callable by both Java and Kotlin.
-        // It must be mocked and stubbed with mockStatic!
         @JvmStatic fun helloStatic(): String = "static_unstubbed"
     }
 

--- a/tests/src/test/kotlin/test/MockingTest.kt
+++ b/tests/src/test/kotlin/test/MockingTest.kt
@@ -18,6 +18,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.mockConstruction
+import org.mockito.kotlin.mockObject
 import org.mockito.kotlin.mockStatic
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -468,6 +469,86 @@ class MockingTest : TestBase() {
 
                 expect(open.stringResult()).toBe("Hello")
             }
+    }
+
+    @Test
+    fun mockObject_basic() {
+        mockObject(MyObject).use {
+            whenever(MyObject.hello()).thenReturn("stubbed")
+
+            expect(MyObject.hello()).toBe("stubbed")
+        }
+    }
+
+    @Test
+    fun mockObject_KStubbing() {
+        mockObject(MyObject) { on { hello() } doReturn "stubbed" }
+            .use { expect(MyObject.hello()).toBe("stubbed") }
+    }
+
+    @Test
+    fun mockStatic_Object_With_JvmStatic_method() {
+        mockStatic<MyObject>().use { mock ->
+            mock.whenever { MyObject.helloStatic() }.thenReturn("stubbed")
+
+            expect(MyObject.helloStatic()).toBe("stubbed")
+        }
+    }
+
+    @Test
+    fun mockCompanionObject_basic() {
+        mockObject(MyClassWithCompanion.Companion).use {
+            val myClassWithCompanionMock = mock<MyClassWithCompanion>()
+            whenever(MyClassWithCompanion.create()).thenReturn(myClassWithCompanionMock)
+
+            expect(MyClassWithCompanion.create()).toBeTheSameAs(myClassWithCompanionMock)
+        }
+    }
+
+    @Test
+    fun mockCompanionObject_KStubbing() {
+        val myClassWithCompanionMock = mock<MyClassWithCompanion>()
+        mockObject(MyClassWithCompanion.Companion) {
+                on { create() } doReturn myClassWithCompanionMock
+            }
+            .use { expect(MyClassWithCompanion.create()).toBeTheSameAs(myClassWithCompanionMock) }
+    }
+
+    @Test
+    fun mockCompanionObject_JvmStatic_method() {
+        mockObject(MyClassWithCompanion.Companion).use {
+            val myClassWithCompanionMock = mock<MyClassWithCompanion>()
+            whenever(MyClassWithCompanion.createStatic()).thenReturn(myClassWithCompanionMock)
+
+            expect(MyClassWithCompanion.createStatic()).toBeTheSameAs(myClassWithCompanionMock)
+        }
+    }
+
+    @Test
+    fun mockObject_nonObjectArgument() {
+        expectErrorWithMessage("is not an object or companion object") on
+            {
+                val m = MyClass()
+                mockObject(m)
+            }
+    }
+
+    object MyObject {
+        fun hello(): String = "unstubbed"
+
+        // This will compile to a static method callable by both Java and Kotlin.
+        // It must be mocked and stubbed with mockStatic!
+        @JvmStatic fun helloStatic(): String = "static_unstubbed"
+    }
+
+    class MyClassWithCompanion {
+        companion object {
+            fun create(): MyClassWithCompanion = MyClassWithCompanion()
+
+            // This will generate a static method, but it is *only* accessible to Java.
+            // Calling Kotlin code still calls the instance method on the Companion class instance.
+            @JvmStatic fun createStatic(): MyClassWithCompanion = MyClassWithCompanion()
+        }
     }
 
     private interface MyInterface


### PR DESCRIPTION
Fixes: #536

This builds off the new `mockSingleton` feature of Mockito-core which enables thread-local intercepting instance methods of existing objects. This was added to enable mocking Kotlin `object` and `companion object` singletons. See https://github.com/mockito/mockito/pull/3762 

Very excited to finally add this feature!

This is comparable to MockK's `mockkObject`.