### PR TITLE
Set Java support version to 8 in root build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id "org.gradle.base"
     id "org.shipkit.shipkit-changelog" version "1.2.0"
@@ -6,6 +8,22 @@ plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
     id "org.jetbrains.kotlin.jvm" version "2.1.20" apply false
     id "org.jetbrains.dokka" version "1.9.10" apply false
+}
+
+allprojects {
+    plugins.withType(JavaPlugin).configureEach {
+        java {
+            toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
+    }
+    plugins.withId("org.jetbrains.kotlin.jvm") {
+        kotlin {
+            jvmToolchain(11) // This handles Kotlin compilation, Java compilation, and Gradle attributes automatically
+            compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+        }
+    }
 }
 
 def test = tasks.register("test") {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id "org.jetbrains.dokka" version "1.9.10" apply false
 }
 
-allprojects {
+subprojects {
     plugins.withType(JavaPlugin).configureEach {
         java {
             toolchain.languageVersion.set(JavaLanguageVersion.of(11))

--- a/mockito-kotlin/build.gradle
+++ b/mockito-kotlin/build.gradle
@@ -1,6 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.dokka"
@@ -41,10 +38,6 @@ dokkaHtml.configure {
             remoteLineSuffix.set("#L")
         }
     }
-}
-
-kotlin {
-    jvmToolchain(11) // This handles Kotlin compilation, Java compilation, and Gradle attributes automatically
 }
 
 javadoc.dependsOn dokkaHtml

--- a/no-coroutine-tests/build.gradle
+++ b/no-coroutine-tests/build.gradle
@@ -12,7 +12,3 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     testImplementation 'junit:junit:4.13.2'
 }
-
-kotlin {
-    jvmToolchain(11) // This handles Kotlin compilation, Java compilation, and Gradle attributes automatically
-}

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -19,7 +19,3 @@ dependencies {
     testImplementation "com.nhaarman:expect.kt:1.0.1"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
 }
-
-kotlin {
-    jvmToolchain(11) // This handles Kotlin compilation, Java compilation, and Gradle attributes automatically
-}


### PR DESCRIPTION
> Thank you for submitting a pull request! But first:
> 
>  - [ ] Can you back your code up with tests?
> 
>   No tests were added because there is no change in the source code, only Gradle scripts.
> 
>  - [x] Please run `./gradlew spotlessApply :tests:spotlessApply` for auto-formatting.

JVM toolchain is set to 11 since version 6.2.1. JVM toolchain locks the installation to the correct version in the local system, which is a good practice. However, without specifying the target, the compiled bytecode also requires 11:

```
Cannot inline bytecode built with JVM target 11 into bytecode that is being built with JVM target 1.8. Specify proper '-jvm-target' option.
```

A large portion of Java projects still target 1.8.