### PR TITLE
Add InOrder verification to MockedStatic

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/KInOrder.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/KInOrder.kt
@@ -26,9 +26,26 @@
 package org.mockito.kotlin
 
 import org.mockito.InOrder
+import org.mockito.MockedStatic
 import org.mockito.verification.VerificationMode
 
 interface KInOrder : InOrder {
+    /**
+     * Verifies certain static behavior happened at least once / exact number of times / never in
+     * order.
+     *
+     * Reorders the arguments of the inherited [verify] so the verification can be passed as a
+     * trailing lambda:
+     * ```
+     * inOrder.verify(mockedStatic, times(2)) { Foo.doSomething() }
+     * ```
+     */
+    fun <T> verify(
+        mock: MockedStatic<T>,
+        mode: VerificationMode,
+        verification: MockedStatic.Verification,
+    )
+
     /**
      * Verifies certain suspending behavior <b>happened once</b> in order.
      *

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/internal/KInOrderDecorator.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/internal/KInOrderDecorator.kt
@@ -26,10 +26,29 @@
 package org.mockito.kotlin.internal
 
 import org.mockito.InOrder
+import org.mockito.MockedStatic
 import org.mockito.kotlin.KInOrder
 import org.mockito.verification.VerificationMode
 
 class KInOrderDecorator(private val inOrder: InOrder) : KInOrder, InOrder by inOrder {
+    /**
+     * Verifies static interaction in order, with exactly one number of invocations.
+     *
+     * Forwarded explicitly because Kotlin class delegation (`InOrder by inOrder`) does not generate
+     * forwarders for Java default methods.
+     */
+    override fun verify(mock: MockedStatic<*>, verification: MockedStatic.Verification) {
+        inOrder.verify(mock, verification)
+    }
+
+    override fun <T> verify(
+        mock: MockedStatic<T>,
+        mode: VerificationMode,
+        verification: MockedStatic.Verification,
+    ) {
+        inOrder.verify(mock, verification, mode)
+    }
+
     override fun <T> verifyBlocking(mock: T, f: suspend T.() -> Unit) {
         val m = verify(mock)
         safeRunBlocking { m.f() }

--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/internal/KInOrderDecorator.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/internal/KInOrderDecorator.kt
@@ -31,16 +31,6 @@ import org.mockito.kotlin.KInOrder
 import org.mockito.verification.VerificationMode
 
 class KInOrderDecorator(private val inOrder: InOrder) : KInOrder, InOrder by inOrder {
-    /**
-     * Verifies static interaction in order, with exactly one number of invocations.
-     *
-     * Forwarded explicitly because Kotlin class delegation (`InOrder by inOrder`) does not generate
-     * forwarders for Java default methods.
-     */
-    override fun verify(mock: MockedStatic<*>, verification: MockedStatic.Verification) {
-        inOrder.verify(mock, verification)
-    }
-
     override fun <T> verify(
         mock: MockedStatic<T>,
         mode: VerificationMode,

--- a/tests/src/test/kotlin/test/MockedStaticTest.kt
+++ b/tests/src/test/kotlin/test/MockedStaticTest.kt
@@ -2,6 +2,8 @@ package test
 
 import org.junit.Test
 import org.mockito.Mockito.mockStatic
+import org.mockito.exceptions.base.MockitoAssertionError
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
@@ -14,6 +16,54 @@ class MockedStaticTest : TestBase() {
             SomeObject.aStaticMethod()
 
             mocked.verify(times(2)) { SomeObject.aStaticMethod() }
+        }
+    }
+
+    @Test
+    fun testInOrderVerifyStatic() {
+        mockStatic(SomeObject::class.java).use { mocked ->
+            SomeObject.aStaticMethod()
+            SomeObject.aStaticMethodReturningString()
+
+            val inOrder = inOrder(SomeObject::class.java)
+            inOrder.verify(mocked) { SomeObject.aStaticMethod() }
+            inOrder.verify(mocked) { SomeObject.aStaticMethodReturningString() }
+        }
+    }
+
+    @Test
+    fun testInOrderVerifyStaticWithMode() {
+        mockStatic(SomeObject::class.java).use { mocked ->
+            SomeObject.aStaticMethod()
+            SomeObject.aStaticMethod()
+            SomeObject.aStaticMethodReturningString()
+
+            val inOrder = inOrder(SomeObject::class.java)
+            inOrder.verify(mocked, times(2)) { SomeObject.aStaticMethod() }
+            inOrder.verify(mocked, times(1)) { SomeObject.aStaticMethodReturningString() }
+        }
+    }
+
+    @Test(expected = MockitoAssertionError::class)
+    fun testInOrderVerifyStaticOutOfOrderFails() {
+        mockStatic(SomeObject::class.java).use { mocked ->
+            SomeObject.aStaticMethod()
+            SomeObject.aStaticMethodReturningString()
+
+            val inOrder = inOrder(SomeObject::class.java)
+            inOrder.verify(mocked) { SomeObject.aStaticMethodReturningString() }
+            inOrder.verify(mocked) { SomeObject.aStaticMethod() }
+        }
+    }
+
+    @Test(expected = MockitoAssertionError::class)
+    fun testInOrderVerifyStaticDefaultIsExactlyOnce() {
+        mockStatic(SomeObject::class.java).use { mocked ->
+            SomeObject.aStaticMethod()
+            SomeObject.aStaticMethod()
+
+            val inOrder = inOrder(SomeObject::class.java)
+            inOrder.verify(mocked) { SomeObject.aStaticMethod() }
         }
     }
 }

--- a/tests/src/test/kotlin/test/MockedStaticTest.kt
+++ b/tests/src/test/kotlin/test/MockedStaticTest.kt
@@ -1,9 +1,9 @@
 package test
 
 import org.junit.Test
-import org.mockito.Mockito.mockStatic
 import org.mockito.exceptions.base.MockitoAssertionError
 import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mockStatic
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
@@ -11,7 +11,7 @@ class MockedStaticTest : TestBase() {
 
     @Test
     fun testVerifyExtensionFun() {
-        mockStatic(SomeObject::class.java).use { mocked ->
+        mockStatic<SomeObject>().use { mocked ->
             SomeObject.aStaticMethod()
             SomeObject.aStaticMethod()
 
@@ -21,7 +21,7 @@ class MockedStaticTest : TestBase() {
 
     @Test
     fun testInOrderVerifyStatic() {
-        mockStatic(SomeObject::class.java).use { mocked ->
+        mockStatic<SomeObject>().use { mocked ->
             SomeObject.aStaticMethod()
             SomeObject.aStaticMethodReturningString()
 
@@ -33,7 +33,7 @@ class MockedStaticTest : TestBase() {
 
     @Test
     fun testInOrderVerifyStaticWithMode() {
-        mockStatic(SomeObject::class.java).use { mocked ->
+        mockStatic<SomeObject>().use { mocked ->
             SomeObject.aStaticMethod()
             SomeObject.aStaticMethod()
             SomeObject.aStaticMethodReturningString()
@@ -46,7 +46,7 @@ class MockedStaticTest : TestBase() {
 
     @Test(expected = MockitoAssertionError::class)
     fun testInOrderVerifyStaticOutOfOrderFails() {
-        mockStatic(SomeObject::class.java).use { mocked ->
+        mockStatic<SomeObject>().use { mocked ->
             SomeObject.aStaticMethod()
             SomeObject.aStaticMethodReturningString()
 
@@ -58,7 +58,7 @@ class MockedStaticTest : TestBase() {
 
     @Test(expected = MockitoAssertionError::class)
     fun testInOrderVerifyStaticDefaultIsExactlyOnce() {
-        mockStatic(SomeObject::class.java).use { mocked ->
+        mockStatic<SomeObject>().use { mocked ->
             SomeObject.aStaticMethod()
             SomeObject.aStaticMethod()
 


### PR DESCRIPTION
Adding the capability to verify static method calls in order.
Also, forwarding InOrder's default method explicitly, since Kotlin class delegation does not generate forwarders for Java default methods.

 - [x] Can you back your code up with tests?
 - [x] Please run `./gradlew spotlessApply` for auto-formatting.
