### PR TITLE
Introduce spyObject

### DIFF
--- a/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
+++ b/mockito-kotlin/src/main/kotlin/org/mockito/kotlin/Mocking.kt
@@ -243,12 +243,12 @@ inline fun <reified T> mockConstruction(): MockedConstruction<T> {
  * }
  * ```
  */
-fun <T : Any> mockObject(instance: T): MockedObject<T> {
+fun <T : Any> mockObject(instance: T, settings: MockSettings = withSettings()): MockedObject<T> {
     if (instance::class.objectInstance == null && !instance::class.isCompanion) {
         throw MockitoKotlinException("$instance is not an object or companion object")
     }
-    val singleton = Mockito.mockSingleton(instance)
-    val static = createMockedStaticIfNeeded(instance)
+    val singleton = Mockito.mockSingleton(instance, settings)
+    val static = createMockedStaticIfNeeded(instance, settings)
     return MockedObject(singleton, static)
 }
 
@@ -279,10 +279,58 @@ fun <T : Any> mockObject(instance: T, stubbing: KStubbing<T>.(T) -> Unit): Mocke
 }
 
 /**
+ * Creates a thread-local spy for an `object` or `companion object` singleton.
+ *
+ * Unlike [mockObject], which replaces all methods with stubs, `spyObject` delegates to the real
+ * implementation by default. Only explicitly stubbed methods are overridden.
+ *
+ * NOTE: This returns a [MockedObject] which must be closed after test execution to prevent mocking
+ * state from leaking to other test cases. You can do this with a `.use {}` block or by calling
+ * [MockedObject.close] manually.
+ *
+ * Example usage:
+ * ```
+ * spyObject(MyObject).use {
+ *     whenever(MyObject.foo()).thenReturn("hello")
+ *     // unstubbed methods call through to real implementations
+ * }
+ * ```
+ */
+fun <T : Any> spyObject(instance: T): MockedObject<T> {
+    val settings = Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS)
+    return mockObject(instance, settings)
+}
+
+/**
+ * Creates a thread-local spy for an `object` or `companion object` singleton, allowing for
+ * immediate stubbing.
+ *
+ * Unlike [mockObject], which replaces all methods with stubs, `spyObject` delegates to the real
+ * implementation by default. Only explicitly stubbed methods are overridden.
+ *
+ * NOTE: This returns a [MockedObject] which must be closed after test execution to prevent mocking
+ * state from leaking to other test cases. You can do this with a `.use {}` block or by calling
+ * [MockedObject.close] manually.
+ *
+ * Example usage:
+ * ```
+ * spyObject(MyObject) {
+ *     on { foo() } doReturn "hello"
+ * }.use { ... }
+ * ```
+ */
+fun <T : Any> spyObject(instance: T, stubbing: KStubbing<T>.(T) -> Unit): MockedObject<T> {
+    return spyObject(instance).apply { KStubbing(instance).stubbing(instance) }
+}
+
+/**
  * If [instance] is a top-level `object` (not a companion) with `@JvmStatic` methods, creates a
  * [MockedStatic] for its class. Returns `null` otherwise.
  */
-private fun <T : Any> createMockedStaticIfNeeded(instance: T): MockedStatic<T>? {
+private fun <T : Any> createMockedStaticIfNeeded(
+    instance: T,
+    settings: MockSettings,
+): MockedStatic<T>? {
     // Companion objects don't need mockStatic — calling Kotlin code always invokes the underlying
     // instance method even for @JvmStatic methods so mockSingleton is sufficient.
     if (instance::class.isCompanion) return null
@@ -295,7 +343,7 @@ private fun <T : Any> createMockedStaticIfNeeded(instance: T): MockedStatic<T>? 
 
     if (!hasStaticMethods) return null
 
-    return Mockito.mockStatic(javaClass) as MockedStatic<T>
+    return Mockito.mockStatic(javaClass, settings) as MockedStatic<T>
 }
 
 /**

--- a/tests/src/test/kotlin/test/MockingTest.kt
+++ b/tests/src/test/kotlin/test/MockingTest.kt
@@ -23,6 +23,7 @@ import org.mockito.kotlin.mockConstruction
 import org.mockito.kotlin.mockExtensionFun
 import org.mockito.kotlin.mockObject
 import org.mockito.kotlin.mockStatic
+import org.mockito.kotlin.spyObject
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.listeners.InvocationListener
@@ -551,6 +552,66 @@ class MockingTest : TestBase() {
                 val m = MyClass()
                 mockObject(m)
             }
+    }
+
+    @Test
+    fun spyObject_callsRealMethodByDefault() {
+        spyObject(MyObject).use { expect(MyObject.hello()).toBe("unstubbed") }
+    }
+
+    @Test
+    fun spyObject_stubbedMethodReturnsStub() {
+        spyObject(MyObject).use {
+            whenever(MyObject.hello()).thenReturn("stubbed")
+
+            expect(MyObject.hello()).toBe("stubbed")
+        }
+    }
+
+    @Test
+    fun spyObject_KStubbing() {
+        spyObject(MyObject) { on { hello() } doReturn "stubbed" }
+            .use { expect(MyObject.hello()).toBe("stubbed") }
+    }
+
+    @Test
+    fun spyObject_JvmStatic_callsRealMethodByDefault() {
+        spyObject(MyObject).use { expect(MyObject.helloStatic()).toBe("static_unstubbed") }
+    }
+
+    @Test
+    fun spyObject_JvmStatic_stubbedMethodReturnsStub() {
+        spyObject(MyObject).use {
+            whenever(MyObject.helloStatic()).thenReturn("static_stubbed")
+
+            expect(MyObject.helloStatic()).toBe("static_stubbed")
+        }
+    }
+
+    @Test
+    fun spyObject_mixed_stubbed_and_real_methods() {
+        spyObject(MyObject).use {
+            whenever(MyObject.hello()).thenReturn("stubbed")
+
+            expect(MyObject.hello()).toBe("stubbed")
+            expect(MyObject.helloStatic()).toBe("static_unstubbed")
+        }
+    }
+
+    @Test
+    fun spyObject_nonObjectArgument() {
+        expectErrorWithMessage("is not an object or companion object") on
+            {
+                val m = MyClass()
+                spyObject(m)
+            }
+    }
+
+    @Test
+    fun spyCompanionObject_callsRealMethodByDefault() {
+        spyObject(MyClassWithCompanion.Companion).use {
+            expect(MyClassWithCompanion.create()).toNotBeNull()
+        }
     }
 
     @Test


### PR DESCRIPTION
This seems useful to have - same as other spy APIs, this configures the mocks with `CALLS_REAL_METHODS` answer.

_____________________

Thank you for submitting a pull request! But first:

 - [X] Can you back your code up with tests?
 - [X] Please run `./gradlew spotlessApply` for auto-formatting.
